### PR TITLE
Better handle check_callsign changes.

### DIFF
--- a/tnc/helpers.py
+++ b/tnc/helpers.py
@@ -252,4 +252,4 @@ def check_callsign(callsign:bytes, crc_to_check:bytes):
             print(call_with_ssid)
             return [True, bytes(call_with_ssid)]
     
-    return False
+    return [False, ""]


### PR DESCRIPTION
This updates the way `check_callsign` results are returned. I found that when `check_callsign` failed, it wasn't returning an array, but simply `False`.  Since it wasn't being checked before trying to access element `[1]` of the array, it threw an exception. This makes the return values more consistent and handles the `False` case more gracefully.