### PR TITLE
Initial attempt to fix issue #179.

### DIFF
--- a/tnc/data_handler.py
+++ b/tnc/data_handler.py
@@ -1011,8 +1011,8 @@ class DATA():
             time.sleep(0.01)
             static.ARQ_SESSION_STATE = 'connecting'
 
-        if static.ARQ_SESSION:
-            static.ARQ_SESSION_STATE = 'connected'
+        if static.ARQ_SESSION and static.ARQ_SESSION_STATE == 'connected':
+            # static.ARQ_SESSION_STATE = 'connected'
             return True
         else:
             static.ARQ_SESSION_STATE = 'failed'
@@ -1059,15 +1059,18 @@ class DATA():
                     # break if data channel is opened    
                     if static.ARQ_SESSION:
                         # eventuell einfach nur return true um die nächste break ebene zu vermeiden?
-                        break
-                if static.ARQ_SESSION:
-                    break
+                        return True
+                # if static.ARQ_SESSION:
+                #     break
         
-        
-                if not static.ARQ_SESSION and attempt == self.session_connect_max_retries:
-                    if not TESTMODE:
-                        self.arq_cleanup()
-                    return False
+            # Session connect timeout, send close_session frame to
+            # attempt to cleanup the far-side, if it received the
+            # open_session frame and can still hear us.
+            if not static.ARQ_SESSION:
+                # if not TESTMODE:
+                #     self.arq_cleanup()
+                self.close_session()
+                return False
                                 
                 
     def received_session_opener(self, data_in:bytes):
@@ -1139,9 +1142,9 @@ class DATA():
     def transmit_session_heartbeat(self):
         """ """
 
-        static.ARQ_SESSION = True
-        static.TNC_STATE = 'BUSY'
-        static.ARQ_SESSION_STATE = 'connected'
+        # static.ARQ_SESSION = True
+        # static.TNC_STATE = 'BUSY'
+        # static.ARQ_SESSION_STATE = 'connected'
 
         frametype = bytes([222])
     
@@ -1294,7 +1297,10 @@ class DATA():
                     self.datachannel_timeout = True
                     if not TESTMODE:
                         self.arq_cleanup()
-                    
+
+                    # attempt to cleanup the far-side, if it received the
+                    # open_session frame and can still hear us.
+                    self.close_session()
                     return False
                     #sys.exit() # close thread and so connection attempts
 
@@ -1943,7 +1949,7 @@ class DATA():
         """
       
         # IRS SIDE        
-        if static.ARQ_STATE and static.TNC_STATE == 'BUSY' and self.is_IRS:
+        if static.ARQ_STATE and static.ARQ_SESSION_STATE == 'connected' and static.TNC_STATE == 'BUSY' and self.is_IRS:
             if self.data_channel_last_received + self.time_list[self.speed_level] > time.time():
                 #print((self.data_channel_last_received + self.time_list[self.speed_level])-time.time())
                 pass
@@ -2029,7 +2035,7 @@ class DATA():
         """
         while 1:
             time.sleep(0.01)
-            if static.ARQ_SESSION and self.IS_ARQ_SESSION_MASTER and not self.arq_file_transfer:
+            if static.ARQ_SESSION and self.IS_ARQ_SESSION_MASTER and static.ARQ_SESSION_STATE == "connected" and not self.arq_file_transfer:
                 time.sleep(1)
                 self.transmit_session_heartbeat()
                 time.sleep(2)


### PR DESCRIPTION
Made a single location where the ARQ state can transition from 'connecting' to 'connected'. Added a few checks of ARQ_SESSION_STATE where I thought they were missing.

Added sending of close session frame when the originating side times out. This can allow for the far-side to transition back to disconnected as well, which also stops the initial problem on non-updated nodes, if they receive the close session frame, without waiting for the 5-minute ARQ session timeout.
