### PR TITLE
Use FRAME_TYPE enum instead of plain int.

### DIFF
--- a/tnc/data_handler.py
+++ b/tnc/data_handler.py
@@ -347,13 +347,6 @@ class DATA:
                 self.log.debug("[TNC] ARQ arq_received_channel_is_open")
                 self.arq_received_channel_is_open(bytes_out[:-2])
 
-            # ARQ MANUAL MODE TRANSMISSION
-            elif (
-                FR_TYPE.ARQ_MANUAL_01.value <= frametype <= FR_TYPE.ARQ_MANUAL_11.value
-            ):
-                self.log.debug("[TNC] ARQ manual mode")
-                self.arq_received_data_channel_opener(bytes_out[:-2])
-
             # ARQ STOP TRANSMISSION
             elif frametype == FR_TYPE.ARQ_STOP.value:
                 self.log.debug("[TNC] ARQ received stop transmission")
@@ -1596,9 +1589,6 @@ class DATA:
             frametype = bytes([FR_TYPE.ARQ_DC_OPEN_W.value])
             self.log.debug("[TNC] Requesting high bandwidth mode")
 
-        if FR_TYPE.ARQ_MANUAL_01.value <= mode <= FR_TYPE.ARQ_MANUAL_11.value:
-            self.log.debug("[TNC] Requesting manual mode --> not yet implemented ")
-            frametype = bytes([mode])
         connection_frame = bytearray(14)
         connection_frame[:1] = frametype
         connection_frame[1:4] = static.DXCALLSIGN_CRC
@@ -1698,11 +1688,6 @@ class DATA:
             self.mode_list = self.mode_list_low_bw
             self.time_list = self.time_list_low_bw
         self.speed_level = len(self.mode_list) - 1
-
-        if FR_TYPE.ARQ_MANUAL_01.value <= frametype <= FR_TYPE.ARQ_MANUAL_11.value:
-            self.log.debug(
-                "[TNC] arq_received_data_channel_opener: manual mode request"
-            )
 
         # Update modes we are listening to
         self.set_listening_modes(self.mode_list[self.speed_level])

--- a/tnc/data_handler.py
+++ b/tnc/data_handler.py
@@ -272,7 +272,7 @@ class DATA:
                 #    self.c_lib.freedv_set_sync(freedv, 0)
 
             # BURST ACK
-            elif frametype == FR_TYPE.ACK.value:
+            elif frametype == FR_TYPE.BURST_ACK.value:
                 self.log.debug("[TNC] ACK RECEIVED....")
                 self.burst_ack_received(bytes_out[:-2])
 
@@ -425,7 +425,7 @@ class DATA:
     def send_burst_ack_frame(self, snr) -> None:
         """Build and send ACK frame for burst DATA frame"""
         ack_frame = bytearray(14)
-        ack_frame[:1] = bytes([FR_TYPE.ACK.value])
+        ack_frame[:1] = bytes([FR_TYPE.BURST_ACK.value])
         ack_frame[1:4] = static.DXCALLSIGN_CRC
         ack_frame[4:7] = static.MYCALLSIGN_CRC
         ack_frame[7:8] = bytes([int(snr)])

--- a/tnc/static.py
+++ b/tnc/static.py
@@ -130,21 +130,8 @@ class FRAME_TYPE(Enum):
     """Lookup for frame types"""
 
     BURST_01 = 10
-    BURST_02 = 11
-    BURST_03 = 12
-    BURST_04 = 13
-    BURST_05 = 14
-    BURST_06 = 15
-    BURST_07 = 16
-    BURST_08 = 17
-    BURST_09 = 18
-    BURST_10 = 19
-    BURST_11 = 20
-    BURST_12 = 21
-    BURST_13 = 22
-    BURST_14 = 23
-    BURST_15 = 24
-    BURST_16 = 25
+    # ...
+    BURST_51 = 50
     ACK = 60
     FR_ACK = 61
     FR_REPEAT = 62
@@ -161,6 +148,9 @@ class FRAME_TYPE(Enum):
     ARQ_DC_OPEN_ACK_W = 226
     ARQ_DC_OPEN_N = 227
     ARQ_DC_OPEN_ACK_N = 228
+    ARQ_MANUAL_01 = 230
+    # ...
+    ARQ_MANUAL_11 = 240
     ARQ_STOP = 249
     BEACON = 250
     TEST_FRAME = 255

--- a/tnc/static.py
+++ b/tnc/static.py
@@ -148,9 +148,6 @@ class FRAME_TYPE(Enum):
     ARQ_DC_OPEN_ACK_W = 226
     ARQ_DC_OPEN_N = 227
     ARQ_DC_OPEN_ACK_N = 228
-    ARQ_MANUAL_01 = 230
-    # ...
-    ARQ_MANUAL_11 = 240
     ARQ_STOP = 249
     BEACON = 250
     TEST_FRAME = 255

--- a/tnc/static.py
+++ b/tnc/static.py
@@ -132,7 +132,7 @@ class FRAME_TYPE(Enum):
     BURST_01 = 10
     # ...
     BURST_51 = 50
-    ACK = 60
+    BURST_ACK = 60
     FR_ACK = 61
     FR_REPEAT = 62
     FR_NACK = 63


### PR DESCRIPTION
Move to using the statoc.FRAME_TYPE enumeration instead of integers for frame types in data_handler.py.
Update FRAME_TYPE enum for missing items.