### PR TITLE
WIP: introduce session id instead of callsign crc check

### DIFF
--- a/tnc/codec2.py
+++ b/tnc/codec2.py
@@ -30,6 +30,7 @@ class FREEDV_MODE(Enum):
     fsk_ldpc = 9
     fsk_ldpc_0 = 200
     fsk_ldpc_1 = 201
+    ofdm_adv = 100
 
 # Function for returning the mode value
 def freedv_get_mode_value_by_name(mode: str) -> int:
@@ -100,6 +101,9 @@ api.freedv_open.restype = ctypes.c_void_p
 api.freedv_open_advanced.argtype = [ctypes.c_int, ctypes.c_void_p]  # type: ignore
 api.freedv_open_advanced.restype = ctypes.c_void_p
 
+api.freedv_open_ofdm_advanced.argtype = [ctypes.c_int, ctypes.c_void_p]  # type: ignore
+api.freedv_open_ofdm_advanced.restype = ctypes.c_void_p
+
 api.freedv_get_bits_per_modem_frame.argtype = [ctypes.c_void_p]  # type: ignore
 api.freedv_get_bits_per_modem_frame.restype = ctypes.c_int
 
@@ -147,8 +151,50 @@ api.FREEDV_MODE_DATAC1 = 10  # type: ignore
 api.FREEDV_MODE_DATAC3 = 12  # type: ignore
 api.FREEDV_MODE_DATAC0 = 14  # type: ignore
 api.FREEDV_MODE_FSK_LDPC = 9  # type: ignore
+api.FREEDV_MODE_OFDM_ADVANCED = 100 # type:ignore
 
 # -------------------------------- FSK LDPC MODE SETTINGS
+
+class OFDM_ADVANCED(ctypes.Structure):
+    """Advanced structure for fsk modes"""
+
+    _fields_ = [
+        ("nc", ctypes.c_int),
+        ("np", ctypes.c_int),
+        ("ns", ctypes.c_int),
+        ("bps", ctypes.c_int),
+        ("nuwbits", ctypes.c_int),
+        ("bad_uw_errors", ctypes.c_int),
+        ("ftwindowwidth", ctypes.c_int),
+        ("edge_pilots", ctypes.c_int),
+        ("ts", ctypes.c_float),
+        ("tcp", ctypes.c_float),
+        ("timing_mx_thresh", ctypes.c_float),
+        #("amp_scale", ctypes.c_float),
+        ("clip_gain1", ctypes.c_float),
+        ("clip_gain2", ctypes.c_float),
+        ("clip_en", ctypes.c_bool),
+        ("txtbits", ctypes.c_int),
+        ("statemachine", ctypes.c_char_p),
+        ("data_mode", ctypes.c_char_p),
+        ("codename", ctypes.c_char_p),
+
+        #("tx_centre", ctypes.c_float),
+        #("rx_centre", ctypes.c_float),
+        ##("fs", ctypes.c_float),
+        ##("rs", ctypes.c_float),
+        ##("bps", ctypes.c_int),
+
+        ("tx_uw", (ctypes.c_uint8 * 64)),
+        #("amp_est_mode", ctypes.c_int),
+        #("tx_bpf_en", ctypes.c_bool),
+        ##("foff_limiter", ctypes.c_bool),
+
+        ##("mode", ctypes.c_char),
+        ##("fmin", ctypes.c_float),
+        ##("fmax", ctypes.c_float)
+    ]
+
 
 
 class ADVANCED(ctypes.Structure):
@@ -187,6 +233,45 @@ H_4096_8192_3d       rate 0.50 (8192,4096)  BPF: 512    not working
 H_16200_9720         rate 0.60 (16200,9720) BPF: 1215   not working
 H_1024_2048_4f       rate 0.50 (2048,1024)  BPF: 128    working
 """
+
+
+api.FREEDV_MODE_OFDM_ADV_SETTINGS = OFDM_ADVANCED()
+api.FREEDV_MODE_OFDM_ADV_SETTINGS.nc = 3
+api.FREEDV_MODE_OFDM_ADV_SETTINGS.np = 12
+api.FREEDV_MODE_OFDM_ADV_SETTINGS.ns = 5
+api.FREEDV_MODE_OFDM_ADV_SETTINGS.bps = 2
+api.FREEDV_MODE_OFDM_ADV_SETTINGS.nuwbits = 32
+api.FREEDV_MODE_OFDM_ADV_SETTINGS.bad_uw_errors = 9
+api.FREEDV_MODE_OFDM_ADV_SETTINGS.ftwindowwidth = 80
+api.FREEDV_MODE_OFDM_ADV_SETTINGS.edge_pilots = 0
+api.FREEDV_MODE_OFDM_ADV_SETTINGS.ts = 0.016
+api.FREEDV_MODE_OFDM_ADV_SETTINGS.tcp = 0.006
+api.FREEDV_MODE_OFDM_ADV_SETTINGS.timing_mx_thresh = 0.08
+api.FREEDV_MODE_OFDM_ADV_SETTINGS.tx_bpf_en = True
+#api.FREEDV_MODE_OFDM_ADV_SETTINGS.amp_scale = 300E3
+api.FREEDV_MODE_OFDM_ADV_SETTINGS.clip_gain1 = 2.2
+api.FREEDV_MODE_OFDM_ADV_SETTINGS.clip_gain2 = 0.85
+api.FREEDV_MODE_OFDM_ADV_SETTINGS.clip_en = True
+api.FREEDV_MODE_OFDM_ADV_SETTINGS.txtbits = 0
+api.FREEDV_MODE_OFDM_ADV_SETTINGS.statemachine = 'data'.encode("utf-8")
+api.FREEDV_MODE_OFDM_ADV_SETTINGS.data_mode = 'streaming'.encode("utf-8")
+api.FREEDV_MODE_OFDM_ADV_SETTINGS.codename = 'H_128_256_5'.encode("utf-8")
+api.FREEDV_MODE_OFDM_ADV_SETTINGS.amp_est_mode = 1
+uwlist = [
+            1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, \
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, \
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, \
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, \
+        ]
+
+#api.FREEDV_MODE_OFDM_ADV_SETTINGS.tx_uw = (ctypes.c_uint8 * len(uwlist))(*uwlist)
+#api.FREEDV_MODE_OFDM_ADV_SETTINGS.tx_uw = (ctypes.c_uint8*64)(*uwlist)
+pointer = (ctypes.c_uint8 * 64)(*uwlist)
+api.FREEDV_MODE_OFDM_ADV_SETTINGS.tx_uw = ctypes.cast(ctypes.byref(pointer), ctypes.POINTER(ctypes.c_uint8 * 64)).contents
+#api.FREEDV_MODE_OFDM_ADV_SETTINGS.tx_uw = ctypes.cast(ctypes.addressof(pointer)-4, ctypes.POINTER(ctypes.c_uint8 * 64)).contents
+
+
+
 # --------------- 2 FSK H_128_256_5, 16 bytes
 api.FREEDV_MODE_FSK_LDPC_0_ADV = ADVANCED()  # type: ignore
 api.FREEDV_MODE_FSK_LDPC_0_ADV.interleave_frames = 0

--- a/tnc/config.py
+++ b/tnc/config.py
@@ -1,0 +1,97 @@
+import configparser
+import structlog
+
+class CONFIG:
+    """
+    CONFIG class for handling with config files
+
+    """
+
+    def __init__(self):
+        # set up logger
+        self.log = structlog.get_logger("CONFIG")
+
+        # init configparser
+        self.config = configparser.ConfigParser(inline_comment_prefixes="#", allow_no_value=True)
+        self.config_name = "config.ini"
+
+        self.log.info("[CFG] logfile init", file=self.config_name)
+
+        # check if log file exists
+        self.config_exists()
+
+    def config_exists(self):
+        """
+        check if config file exists
+        """
+        try:
+            return bool(self.config.read(self.config_name, None))
+        except Exception as configerror:
+            self.log.error("[CFG] logfile init error", e=configerror)
+            return False
+
+    def write_config(self, section: str, key: str, value):
+        """
+        write values to config
+        """
+
+    def write_entire_config(self, data):
+        """
+        write entire config
+        """
+        #self.config['DEFAULT'] = {'':''}
+
+        self.config['NETWORK'] = {'#Network settings': None,
+                                  'TNCPORT': 0
+                                  }
+
+        self.config['STATION'] = {'#Station settings': None,
+                                  'mycall' : data[1],
+                                  'mygrid' : data[2]
+                                  }
+
+        self.config['AUDIO'] = {'#Audio settings': None,
+                                'rx': data[3],
+                                'tx': data[4],
+                                'txaudiolevel': data[22]
+
+                                }
+        self.config['RADIO'] = {'#Radio settings': None,
+                                'radiocontrol': data[13],
+                                'devicename': data[5],
+                                'deviceport': data[6],
+                                'serialspeed': data[7],
+                                'pttprotocol': data[8],
+                                'pttport': data[9],
+                                'data_bits': data[10],
+                                'stop_bits': data[11],
+                                'handshake': data[12],
+                                'rigctld_ip': data[14],
+                                'rigctld_port': data[15]
+                                }
+        self.config['TNC'] = {'#TNC settings': None,
+                              'scatter': data[16],
+                              'fft': data[17],
+                              'narrowband': data[18],
+                              'fmin': data[19],
+                              'fmax': data[20],
+                              'qrv': data[23],
+                              'rxbuffersize': data[24]
+                              }
+        try:
+            with open(self.config_name, 'w') as configfile:
+                self.config.write(configfile)
+        except Exception as conferror:
+            pass
+
+
+    def read_config(self):
+        """
+        read config file
+        """
+        if self.config_exists():
+            #print(self.config.read(self.config_name))
+            #print(self.config.sections())
+
+            return self.config
+

--- a/tnc/config.py
+++ b/tnc/config.py
@@ -39,15 +39,13 @@ class CONFIG:
         """
         write entire config
         """
-        #self.config['DEFAULT'] = {'':''}
-
         self.config['NETWORK'] = {'#Network settings': None,
-                                  'TNCPORT': 0
+                                  'TNCPORT': data[50]
                                   }
 
         self.config['STATION'] = {'#Station settings': None,
-                                  'mycall' : data[1],
-                                  'mygrid' : data[2]
+                                  'mycall': data[1],
+                                  'mygrid': data[2]
                                   }
 
         self.config['AUDIO'] = {'#Audio settings': None,

--- a/tnc/config.py
+++ b/tnc/config.py
@@ -82,7 +82,7 @@ class CONFIG:
             with open(self.config_name, 'w') as configfile:
                 self.config.write(configfile)
         except Exception as conferror:
-            pass
+            self.log.error("[CFG] reading logfile", e=conferror)
 
 
     def read_config(self):

--- a/tnc/daemon.py
+++ b/tnc/daemon.py
@@ -128,6 +128,9 @@ class DAEMON:
         while True:
             try:
                 data = self.daemon_queue.get()
+                # increase length of list for storing additional
+                # parameters starting at entry 64
+                data = data[:64] + [None] * (64 - len(data))
 
                 # data[1] mycall
                 # data[2] mygrid
@@ -163,6 +166,8 @@ class DAEMON:
 
                     options.append("--port")
                     options.append(str(static.DAEMONPORT - 1))
+                    # create an additional list entry for parameters not covered by gui
+                    data[50] = int(static.DAEMONPORT - 1)
 
                     options.append("--mycall")
                     options.append(data[1])

--- a/tnc/daemon.py
+++ b/tnc/daemon.py
@@ -21,7 +21,6 @@ import subprocess
 import sys
 import threading
 import time
-
 import audio
 import crcengine
 import log_handler
@@ -30,6 +29,8 @@ import sock
 import static
 import structlog
 import ujson as json
+import config
+
 
 
 # signal handler for closing application
@@ -242,6 +243,9 @@ class DAEMON:
                     options.append("--rx-buffer-size")
                     options.append(data[24])
 
+                    # safe data to config file
+                    config.write_entire_config(data)
+
                     # Try running tnc from binary, else run from source
                     # This helps running the tnc in a developer environment
                     try:
@@ -391,6 +395,9 @@ if __name__ == "__main__":
         log_handler.setup_logging(logging_path)
     except Exception as err:
         mainlog.error("[DMN] logger init error", exception=err)
+
+    # init config
+    config = config.CONFIG()
 
     try:
         mainlog.info("[DMN] Starting TCP/IP socket", port=static.DAEMONPORT)

--- a/tnc/data_handler.py
+++ b/tnc/data_handler.py
@@ -280,7 +280,7 @@ class DATA:
         frametype = int.from_bytes(bytes(bytes_out[:1]), "big")
         _valid1, _ = helpers.check_callsign(self.mycallsign, bytes(bytes_out[1:4]))
         _valid2, _ = helpers.check_callsign(self.mycallsign, bytes(bytes_out[2:5]))
-        _valid3, _ = helpers.check_session_id(self.session_id, bytes(bytes_out[1:2]))
+        _valid3 = helpers.check_session_id(self.session_id, bytes(bytes_out[1:2]))
 
 
         if (
@@ -2158,7 +2158,7 @@ class DATA:
         if static.ENABLE_FSK:
             self.enqueue_frame_for_tx(cq_frame, c2_mode=FREEDV_MODE.fsk_ldpc_0.value)
         else:
-            self.enqueue_frame_for_tx(cq_frame)
+            self.enqueue_frame_for_tx(cq_frame, c2_mode=FREEDV_MODE.ofdm_adv.value)
 
     def received_cq(self, data_in: bytes) -> None:
         """

--- a/tnc/helpers.py
+++ b/tnc/helpers.py
@@ -278,6 +278,17 @@ def bytes_to_callsign(bytestring: bytes) -> bytes:
     return bytes(f"{callsign}-{ssid}", "utf-8")
 
 
+def check_session_id(id: bytes, id_to_check: bytes):
+    """
+    Funktion to check if we received the correct session id
+    """
+    if id == id_to_check:
+        return True
+    else:
+        return False
+
+
+
 def check_callsign(callsign: bytes, crc_to_check: bytes):
     """
     Function to check a crc against a callsign to calculate the

--- a/tnc/main.py
+++ b/tnc/main.py
@@ -194,7 +194,7 @@ if __name__ == "__main__":
     )
     PARSER.add_argument(
         "--fft",
-        dest="send_fft",
+        dest="fft",
         action="store_true",
         help="Send fft information via network",
     )
@@ -247,7 +247,29 @@ if __name__ == "__main__":
         type=int,
     )
 
+
     ARGS = PARSER.parse_args()
+
+
+    print("##################")
+    for arg in sys.argv:
+        print("------")
+        arg_clean = arg.replace('--', '')
+
+        if arg in ARGS:
+            print(arg)
+            print(vars(ARGS).get(arg))
+            PARSER.add_argument(
+                arg,
+                dest=arg_clean,
+                default=vars(ARGS).get(arg),
+                type=type(vars(ARGS).get(arg)),
+            )
+    print("##################")
+
+
+
+    print("---------------------------------")
     if ARGS.configfile:
         # init config
         config = config.CONFIG().read_config()
@@ -286,7 +308,6 @@ if __name__ == "__main__":
         static.RESPOND_TO_CQ = config['TNC']['qrv']
         static.RX_BUFFER_SIZE = config['TNC']['rxbuffersize']
 
-
     else:
         # additional step for being sure our callsign is correctly
         # in case we are not getting a station ssid
@@ -313,7 +334,7 @@ if __name__ == "__main__":
         static.HAMLIB_RIGCTLD_IP = ARGS.rigctld_ip
         static.HAMLIB_RIGCTLD_PORT = str(ARGS.rigctld_port)
         static.ENABLE_SCATTER = ARGS.send_scatter
-        static.ENABLE_FFT = ARGS.send_fft
+        static.ENABLE_FFT = ARGS.fft
         static.ENABLE_FSK = ARGS.enable_fsk
         static.LOW_BANDWIDTH_MODE = ARGS.low_bandwidth_mode
         static.TUNING_RANGE_FMIN = ARGS.tuning_range_fmin

--- a/tnc/main.py
+++ b/tnc/main.py
@@ -264,7 +264,7 @@ if __name__ == "__main__":
         static.MYGRID = bytes(config['STATION']['mygrid'], "utf-8")
         static.AUDIO_INPUT_DEVICE = int(config['AUDIO']['rx'])
         static.AUDIO_OUTPUT_DEVICE = int(config['AUDIO']['tx'])
-        static.PORT = 0 ####
+        static.PORT = int(config['NETWORK']['tncport'])
         static.HAMLIB_DEVICE_NAME = config['RADIO']['devicename']
         static.HAMLIB_DEVICE_PORT = config['RADIO']['deviceport']
         static.HAMLIB_PTT_TYPE = config['RADIO']['pttprotocol']

--- a/tnc/modem.py
+++ b/tnc/modem.py
@@ -82,9 +82,20 @@ class RF:
 
         # Open codec2 instances
         # Datac0 - control frames
+        #self.datac0_freedv = ctypes.cast(
+        #    codec2.api.freedv_open(codec2.api.FREEDV_MODE_DATAC0), ctypes.c_void_p
+        #)
+        print(codec2.api.FREEDV_MODE_OFDM_ADV_SETTINGS)
         self.datac0_freedv = ctypes.cast(
-            codec2.api.freedv_open(codec2.api.FREEDV_MODE_DATAC0), ctypes.c_void_p
+            codec2.api.freedv_open_ofdm_advanced(
+                codec2.api.FREEDV_MODE_OFDM_ADVANCED,
+                ctypes.byref(codec2.api.FREEDV_MODE_OFDM_ADV_SETTINGS),
+            ),
+            ctypes.c_void_p,
         )
+
+
+
         self.c_lib.freedv_set_tuning_range(
             self.datac0_freedv,
             ctypes.c_float(static.TUNING_RANGE_FMIN),
@@ -442,15 +453,13 @@ class RF:
         # Open codec2 instance
         self.MODE = mode
         freedv = open_codec2_instance(self.MODE)
-
         # Get number of bytes per frame for mode
         bytes_per_frame = int(codec2.api.freedv_get_bits_per_modem_frame(freedv) / 8)
-        payload_bytes_per_frame = bytes_per_frame - 2
 
+        payload_bytes_per_frame = bytes_per_frame - 2
         # Init buffer for data
         n_tx_modem_samples = codec2.api.freedv_get_n_tx_modem_samples(freedv)
         mod_out = ctypes.create_string_buffer(n_tx_modem_samples * 2)
-
         # Init buffer for preample
         n_tx_preamble_modem_samples = codec2.api.freedv_get_n_tx_preamble_modem_samples(
             freedv
@@ -872,6 +881,7 @@ class RF:
 
         codec2.api.freedv_set_frames_per_burst(self.datac1_freedv, frames_per_burst)
         codec2.api.freedv_set_frames_per_burst(self.datac3_freedv, frames_per_burst)
+
         codec2.api.freedv_set_frames_per_burst(self.fsk_ldpc_freedv_0, frames_per_burst)
 
 
@@ -884,6 +894,18 @@ def open_codec2_instance(mode: int) -> ctypes.c_void_p:
     :return: C-function of the requested codec2 instance
     :rtype: ctypes.c_void_p
     """
+
+    if mode in [codec2.FREEDV_MODE.ofdm_adv.value]:
+        return ctypes.cast(
+            codec2.api.freedv_open_ofdm_advanced(
+                codec2.api.FREEDV_MODE_OFDM_ADVANCED,
+                ctypes.byref(codec2.api.FREEDV_MODE_OFDM_ADV_SETTINGS),
+            ),
+
+            ctypes.c_void_p,
+        )
+
+
     if mode in [codec2.FREEDV_MODE.fsk_ldpc_0.value]:
         return ctypes.cast(
             codec2.api.freedv_open_advanced(


### PR DESCRIPTION
Using the 24bit callsign crc is really inefficient during an ongoing transmission. For this reason a `session_id` will be introduced - a 8bit random byte string.
By using the session id we can reduce protocol overhead by 5 bytes. This should open possibilities in using a slower and more robust modulation for signalling frames. 


Todo:

- [ ] Ad additional mode for signalling frames with goal of using LDPC 56,56 code with a payload of 7-2 bytes ( 5bytes available)
- [ ] Listen to mode used of ACK only when datachannel openend.
- [ ] Use existing signalling mode only for opening a data channel, then stop listening for reducing CPU load. 

Note this mode depends highly on not existing codec2 data modes --> WIP! 