### PR TITLE
Set waterfall theme and small wf optimization

### DIFF
--- a/gui/main.js
+++ b/gui/main.js
@@ -92,7 +92,8 @@ const configDefaultSettings = '{\
                   "tuning_range_fmax" : "50.0",\
                   "respond_to_cq" : "True",\
                   "rx_buffer_size" : "16", \
-                  "enable_explorer" : "False" \
+                  "enable_explorer" : "False", \
+                  "wftheme": 2 \
                   }';
 
 if (!fs.existsSync(configPath)) {

--- a/gui/preload-main.js
+++ b/gui/preload-main.js
@@ -413,10 +413,13 @@ document.getElementById('openReceivedFilesFolder').addEventListener('click', () 
     // Create spectrum object on canvas with ID "waterfall"
     global.spectrum = new Spectrum(
         "waterfall", {
-            spectrumPercent: 0
+            spectrumPercent: 0,
+            wf_rows: 192    //Assuming 1 row = 1 pixe1, 192 is the height of the spectrum container
         });
 
-
+    //Set waterfalltheme
+    document.getElementById("wftheme_selector").value = config.wftheme;
+    spectrum.setColorMap(config.wftheme);
 
     // on click radio control toggle view
     // disabled
@@ -1121,8 +1124,16 @@ document.getElementById('hamlib_rigctld_stop').addEventListener('click', () => {
         fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
 
     });
+
+    // Waterfall theme selector changed
+    document.getElementById("wftheme_selector").addEventListener("change", () => {
+        var wftheme = document.getElementById("wftheme_selector").value;
+        spectrum.setColorMap(wftheme);
+        config.wftheme = wftheme;
+        fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
+    });
     
-    // Update channel selector clicked
+        // Update channel selector clicked
     document.getElementById("update_channel_selector").addEventListener("click", () => {
         config.update_channel = document.getElementById("update_channel_selector").value;
         fs.writeFileSync(configPath, JSON.stringify(config, null, 2));

--- a/gui/src/index.html
+++ b/gui/src/index.html
@@ -1192,6 +1192,17 @@
 							<option value="zephyr">Zephyr</option>
 						</select>
 					</div>
+					<div class="input-group input-group-sm mb-1"> <span class="input-group-text w-50" id="basic-addon1">Waterfall Theme</span>
+						<select class="form-select form-select-sm w-50" id="wftheme_selector">
+							<option value="2">Default</option>
+							<option value="0">Turbo</option>
+							<option value="1">Fosphor</option>
+							<option value="3">Inferno</option>
+							<option value="4">Magma</option>
+							<option value="5">Jet</option>
+							<option value="6">Binary</option>
+						</select>
+					</div>
 					<div class="input-group input-group-sm mb-1"> <span class="input-group-text w-50" id="basic-addon1">Update channel</span>
 						<select class="form-select form-select-sm w-50" id="update_channel_selector">
 							<option value="latest">stable</option>

--- a/gui/src/waterfall/spectrum.js
+++ b/gui/src/waterfall/spectrum.js
@@ -68,7 +68,8 @@ Spectrum.prototype.drawFFT = function(bins) {
     this.ctx.stroke();
 }
 
-Spectrum.prototype.drawSpectrum = function(bins) {
+//Spectrum.prototype.drawSpectrum = function(bins) {
+    Spectrum.prototype.drawSpectrum = function() {
     var width = this.ctx.canvas.width;
     var height = this.ctx.canvas.height;
 
@@ -242,7 +243,8 @@ Spectrum.prototype.addData = function(data) {
             this.ctx_wf.fillRect(0, 0, this.wf.width, this.wf.height);
             this.imagedata = this.ctx_wf.createImageData(data.length, 1);
         }
-        this.drawSpectrum(data);
+        //this.drawSpectrum(data);
+        this.drawSpectrum();
         this.addWaterfallRow(data);
         this.resize();
     }

--- a/gui/src/waterfall/spectrum.js
+++ b/gui/src/waterfall/spectrum.js
@@ -88,40 +88,34 @@ Spectrum.prototype.drawSpectrum = function(bins) {
     this.ctx_wf.stroke()
     */
 
-    // 586Hz LINES
-    var bandwidth = 568;
-    var linePositionLow = 150 - ((bandwidth/2)/10);
-    var linePositionHigh = 150 + ((bandwidth/2)/10);
+    // 586Hz and 1700Hz LINES
+    var linePositionLow = 121.6;     //150 - bandwith/20
+    var linePositionHigh = 178.4;    //150 + bandwidth/20
+    var linePositionLow2 = 65;       //150 - bandwith/20
+    var linePositionHigh2 = 235;     //150 + bandwith/20  
     this.ctx_wf.beginPath();
     this.ctx_wf.moveTo(linePositionLow,0);
     this.ctx_wf.lineTo(linePositionLow, height);
     this.ctx_wf.moveTo(linePositionHigh,0);
     this.ctx_wf.lineTo(linePositionHigh, height);
+    this.ctx_wf.moveTo(linePositionLow2,0);
+    this.ctx_wf.lineTo(linePositionLow2, height);
+    this.ctx_wf.moveTo(linePositionHigh2,0);
+    this.ctx_wf.lineTo(linePositionHigh2, height);
     this.ctx_wf.lineWidth = 1;
     this.ctx_wf.strokeStyle = '#C3C3C3';
     this.ctx_wf.stroke()
 
-    // 1700Hz LINES
-    var bandwidth = 1700;
-    var linePositionLow = 150 - ((bandwidth/2)/10);
-    var linePositionHigh = 150 + ((bandwidth/2)/10);
-    this.ctx_wf.beginPath();
-    this.ctx_wf.moveTo(linePositionLow,0);
-    this.ctx_wf.lineTo(linePositionLow, height);
-    this.ctx_wf.moveTo(linePositionHigh,0);
-    this.ctx_wf.lineTo(linePositionHigh, height);
-    this.ctx_wf.lineWidth = 1;
-    this.ctx_wf.strokeStyle = '#C3C3C3';
-    this.ctx_wf.stroke()
-
-
-    // ---- END OF MODIFICATION ------
+   // ---- END OF MODIFICATION ------
 
 
     // Fill with black
     this.ctx.fillStyle = "white";
     this.ctx.fillRect(0, 0, width, height);
 
+    //Commenting out the remainder of this code, it's not needed and unused as of 6.9.11 and saves three if statements
+    return;
+    /*
     // FFT averaging
     if (this.averaging > 0) {
         if (!this.binsAverage || this.binsAverage.length != bins.length) {
@@ -174,6 +168,12 @@ Spectrum.prototype.drawSpectrum = function(bins) {
 
     // Copy axes from offscreen canvas
     this.ctx.drawImage(this.ctx_axes.canvas, 0, 0);
+    */
+}
+
+//Allow setting colormap
+Spectrum.prototype.setColorMap = function(index) {
+    this.colormap = colormaps[index];
 }
 
 Spectrum.prototype.updateAxes = function() {


### PR DESCRIPTION
Allows setting a different colormap to waterfall.

Limit waterfall rows to 192 vs 1024 which is the default.  Waterfall container is 192 pixels and everything is still visible until it scrolls off.  

Use constants for lines drawn on waterfall for less calculations and commented out some code that is not needed in spectrum.js related to drawing the spectrum.