### PR TITLE
GUI adjustments

### DIFF
--- a/gui/package.json
+++ b/gui/package.json
@@ -32,7 +32,7 @@
     "@electron/osx-sign": "^1.0.4",
     "@popperjs/core": "^2.11.6",
     "blob-util": "^2.0.2",
-    "bootstrap": "^5.2.3",
+    "bootstrap": "^5.3.0-alpha.1",
     "bootstrap-icons": "^1.10.3",
     "bootswatch": "^5.2.3",
     "browser-image-compression": "^2.0.0",

--- a/gui/preload-chat.js
+++ b/gui/preload-chat.js
@@ -144,7 +144,7 @@ updateAllChat(false);
 // WINDOW LISTENER
 window.addEventListener("DOMContentLoaded", () => {
   // theme selector
-  changeGuiDesign(config.theme)
+  changeGuiDesign(config.theme);
 
   const userInfoFields = [
     "user_info_image",
@@ -2230,10 +2230,9 @@ function sendFileReq(dxcall, file) {
   });
 }
 
-
-function changeGuiDesign(design){
-console.log(design)
-if (
+function changeGuiDesign(design) {
+  console.log(design);
+  if (
     design != "default" &&
     design != "default_light" &&
     design != "default_dark" &&
@@ -2284,8 +2283,5 @@ if (
   }
 
   //update path to css file
-    document.getElementById("bootstrap_theme").href = escape(theme_path);
-
-
-
+  document.getElementById("bootstrap_theme").href = escape(theme_path);
 }

--- a/gui/preload-chat.js
+++ b/gui/preload-chat.js
@@ -998,9 +998,9 @@ update_chat = function (obj) {
 
       var controlarea_transmit = `
         <div class="ms-auto" id="msg-${obj._id}-control-area">
-                <button class="btn bg-transparent p-1 m-1"><i class="bi bi-arrow-repeat" id="retransmit-msg-${obj._id}" style="font-size: 1.2rem; color: grey;"></i></button>
-                <button class="btn bg-transparent p-1 m-1"><i class="bi bi-download" id="save-file-msg-${obj._id}" style="font-size: 1.2rem; color: grey;"></i></button>
-                <button class="btn bg-transparent p-1 m-1"><i class="bi bi-trash" id="del-msg-${obj._id}" style="font-size: 1.2rem; color: grey;"></i></button>
+                <button class="btn bg-transparent p-1 m-1"><i class="bi bi-arrow-repeat" id="retransmit-msg-${obj._id}" style="font-size: 1.2rem;"></i></button>
+                <button class="btn bg-transparent p-1 m-1"><i class="bi bi-download" id="save-file-msg-${obj._id}" style="font-size: 1.2rem;"></i></button>
+                <button class="btn bg-transparent p-1 m-1"><i class="bi bi-trash" id="del-msg-${obj._id}" style="font-size: 1.2rem;"></i></button>
              </div>
 
         `;
@@ -1008,8 +1008,8 @@ update_chat = function (obj) {
       var controlarea_receive = `
 
              <div class="me-auto" id="msg-${obj._id}-control-area">
-                <button class="btn bg-transparent p-1 m-1"><i class="bi bi-download" id="save-file-msg-${obj._id}" style="font-size: 1.2rem; color: grey;"></i></button>
-                <button class="btn bg-transparent p-1 m-1"><i class="bi bi-trash" id="del-msg-${obj._id}" style="font-size: 1.2rem; color: grey;"></i></button>
+                <button class="btn bg-transparent p-1 m-1"><i class="bi bi-download" id="save-file-msg-${obj._id}" style="font-size: 1.2rem;"></i></button>
+                <button class="btn bg-transparent p-1 m-1"><i class="bi bi-trash" id="del-msg-${obj._id}" style="font-size: 1.2rem;"></i></button>
              </div>
 
         `;
@@ -1019,13 +1019,13 @@ update_chat = function (obj) {
       var filetype = "text/plain";
       var controlarea_transmit = `
 <div class="ms-auto" id="msg-${obj._id}-control-area">
-                <button class="btn bg-transparent p-1 m-1"><i class="bi bi-arrow-repeat" id="retransmit-msg-${obj._id}" style="font-size: 1.2rem; color: grey;"></i></button>
-                <button class="btn bg-transparent p-1 m-1"><i class="bi bi-trash" id="del-msg-${obj._id}" style="font-size: 1.2rem; color: grey;"></i></button>
+                <button class="btn bg-transparent p-1 m-1"><i class="bi bi-arrow-repeat" id="retransmit-msg-${obj._id}" style="font-size: 1.2rem;"></i></button>
+                <button class="btn bg-transparent p-1 m-1"><i class="bi bi-trash" id="del-msg-${obj._id}" style="font-size: 1.2rem;"></i></button>
              </div>
         `;
       var controlarea_receive = `
       <div class="float-start" id="msg-${obj._id}-control-area">
-                      <button class="btn bg-transparent p-1 m-1"><i class="bi bi-trash" id="del-msg-${obj._id}" style="font-size: 1.2rem; color: grey;"></i></button>
+                      <button class="btn bg-transparent p-1 m-1"><i class="bi bi-trash" id="del-msg-${obj._id}" style="font-size: 1.2rem;"></i></button>
                    </div>
               `;
     }
@@ -1221,7 +1221,7 @@ update_chat = function (obj) {
 
                             <!--<button type="button" id="retransmit-msg-${
                               obj._id
-                            }" class="btn btn-sm btn-light p-0" style="height:20px;width:30px"><i class="bi bi-arrow-repeat" style="font-size: 0.9rem; color: black;"></i></button>-->
+                            }" class="btn btn-sm btn-light p-0" style="height:20px;width:30px"><i class="bi bi-arrow-repeat" style="font-size: 0.9rem;"></i></button>-->
 
                         </p>
 

--- a/gui/preload-chat.js
+++ b/gui/preload-chat.js
@@ -162,8 +162,32 @@ window.addEventListener("DOMContentLoaded", () => {
     document.getElementById("bootstrap_theme").href = escape(theme_path);
     document.querySelector("html").setAttribute("data-bs-theme", "dark");
   } else if (config.theme == "default_auto") {
+
     var theme_path = "../node_modules/bootstrap/dist/css/bootstrap.min.css";
-    document.getElementById("bootstrap_theme").href = escape(theme_path);
+        document.getElementById("bootstrap_theme").href = escape(theme_path);
+
+        // https://stackoverflow.com/a/57795495
+        // check if dark mode or light mode used in OS
+        if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+        // dark mode
+            document.documentElement.setAttribute("data-bs-theme", "dark");
+        } else {
+            document.documentElement.setAttribute("data-bs-theme", "light");
+        }
+
+        // also register event listener for automatic change
+        window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', event => {
+        let newColorScheme = event.matches ? "dark" : "light";
+        if(newColorScheme == "dark"){
+            document.documentElement.setAttribute("data-bs-theme", "dark");
+        } else {
+            document.documentElement.setAttribute("data-bs-theme", "light");
+        }
+
+        });
+
+
+
   } else {
     var theme_path = "../node_modules/bootstrap/dist/css/bootstrap.min.css";
     document.getElementById("bootstrap_theme").href = escape(theme_path);

--- a/gui/preload-chat.js
+++ b/gui/preload-chat.js
@@ -144,55 +144,7 @@ updateAllChat(false);
 // WINDOW LISTENER
 window.addEventListener("DOMContentLoaded", () => {
   // theme selector
-  if (
-    config.theme != "default" &&
-    config.theme != "default_light" &&
-    config.theme != "default_dark" &&
-    config.theme != "default_auto"
-  ) {
-    var theme_path =
-      "../node_modules/bootswatch/dist/" + config.theme + "/bootstrap.min.css";
-    document.getElementById("bootstrap_theme").href = escape(theme_path);
-  } else if (config.theme == "default" || config.theme == "default_light") {
-    var theme_path = "../node_modules/bootstrap/dist/css/bootstrap.min.css";
-    document.getElementById("bootstrap_theme").href = escape(theme_path);
-    document.documentElement.setAttribute("data-bs-theme", "light");
-  } else if (config.theme == "default_dark") {
-    var theme_path = "../node_modules/bootstrap/dist/css/bootstrap.min.css";
-    document.getElementById("bootstrap_theme").href = escape(theme_path);
-    document.querySelector("html").setAttribute("data-bs-theme", "dark");
-  } else if (config.theme == "default_auto") {
-    var theme_path = "../node_modules/bootstrap/dist/css/bootstrap.min.css";
-    document.getElementById("bootstrap_theme").href = escape(theme_path);
-
-    // https://stackoverflow.com/a/57795495
-    // check if dark mode or light mode used in OS
-    if (
-      window.matchMedia &&
-      window.matchMedia("(prefers-color-scheme: dark)").matches
-    ) {
-      // dark mode
-      document.documentElement.setAttribute("data-bs-theme", "dark");
-    } else {
-      document.documentElement.setAttribute("data-bs-theme", "light");
-    }
-
-    // also register event listener for automatic change
-    window
-      .matchMedia("(prefers-color-scheme: dark)")
-      .addEventListener("change", (event) => {
-        let newColorScheme = event.matches ? "dark" : "light";
-        if (newColorScheme == "dark") {
-          document.documentElement.setAttribute("data-bs-theme", "dark");
-        } else {
-          document.documentElement.setAttribute("data-bs-theme", "light");
-        }
-      });
-  } else {
-    var theme_path = "../node_modules/bootstrap/dist/css/bootstrap.min.css";
-    document.getElementById("bootstrap_theme").href = escape(theme_path);
-    document.documentElement.setAttribute("data-bs-theme", "light");
-  }
+  changeGuiDesign(config.theme)
 
   const userInfoFields = [
     "user_info_image",
@@ -2276,4 +2228,64 @@ function sendFileReq(dxcall, file) {
     dxcallsign: dxcall,
     file: file,
   });
+}
+
+
+function changeGuiDesign(design){
+console.log(design)
+if (
+    design != "default" &&
+    design != "default_light" &&
+    design != "default_dark" &&
+    design != "default_auto"
+  ) {
+    var theme_path =
+      "../node_modules/bootswatch/dist/" + design + "/bootstrap.min.css";
+    document.getElementById("bootstrap_theme").href = escape(theme_path);
+  } else if (design == "default" || design == "default_light") {
+    var theme_path = "../node_modules/bootstrap/dist/css/bootstrap.min.css";
+    document.getElementById("bootstrap_theme").href = escape(theme_path);
+    document.documentElement.setAttribute("data-bs-theme", "light");
+  } else if (design == "default_dark") {
+    var theme_path = "../node_modules/bootstrap/dist/css/bootstrap.min.css";
+    document.getElementById("bootstrap_theme").href = escape(theme_path);
+    document.querySelector("html").setAttribute("data-bs-theme", "dark");
+  } else if (design == "default_auto") {
+    var theme_path = "../node_modules/bootstrap/dist/css/bootstrap.min.css";
+    document.getElementById("bootstrap_theme").href = escape(theme_path);
+
+    // https://stackoverflow.com/a/57795495
+    // check if dark mode or light mode used in OS
+    if (
+      window.matchMedia &&
+      window.matchMedia("(prefers-color-scheme: dark)").matches
+    ) {
+      // dark mode
+      document.documentElement.setAttribute("data-bs-theme", "dark");
+    } else {
+      document.documentElement.setAttribute("data-bs-theme", "light");
+    }
+
+    // also register event listener for automatic change
+    window
+      .matchMedia("(prefers-color-scheme: dark)")
+      .addEventListener("change", (event) => {
+        let newColorScheme = event.matches ? "dark" : "light";
+        if (newColorScheme == "dark") {
+          document.documentElement.setAttribute("data-bs-theme", "dark");
+        } else {
+          document.documentElement.setAttribute("data-bs-theme", "light");
+        }
+      });
+  } else {
+    var theme_path = "../node_modules/bootstrap/dist/css/bootstrap.min.css";
+    document.getElementById("bootstrap_theme").href = escape(theme_path);
+    document.documentElement.setAttribute("data-bs-theme", "light");
+  }
+
+  //update path to css file
+    document.getElementById("bootstrap_theme").href = escape(theme_path);
+
+
+
 }

--- a/gui/preload-chat.js
+++ b/gui/preload-chat.js
@@ -144,13 +144,29 @@ updateAllChat(false);
 // WINDOW LISTENER
 window.addEventListener("DOMContentLoaded", () => {
   // theme selector
-  if (config.theme != "default") {
+  if (config.theme != "default" && config.theme != "default_light" && config.theme != "default_dark" && config.theme != "default_auto") {
     var theme_path =
       "../node_modules/bootswatch/dist/" + config.theme + "/bootstrap.min.css";
-    document.getElementById("bootstrap_theme").href = theme_path;
+    document.getElementById("bootstrap_theme").href = escape(theme_path);
+
+  } else if (config.theme == "default" || config.theme == "default_light"){
+    var theme_path = "../node_modules/bootstrap/dist/css/bootstrap.min.css";
+    document.getElementById("bootstrap_theme").href = escape(theme_path);
+    document.documentElement.setAttribute('data-bs-theme','light')
+
+  } else if (config.theme == "default_dark") {
+    var theme_path = "../node_modules/bootstrap/dist/css/bootstrap.min.css";
+    document.getElementById("bootstrap_theme").href = escape(theme_path);
+    document.querySelector("html").setAttribute('data-bs-theme','dark')
+
+  } else if (config.theme == "default_auto") {
+    var theme_path = "../node_modules/bootstrap/dist/css/bootstrap.min.css";
+    document.getElementById("bootstrap_theme").href = escape(theme_path);
+
   } else {
     var theme_path = "../node_modules/bootstrap/dist/css/bootstrap.min.css";
-    document.getElementById("bootstrap_theme").href = theme_path;
+    document.getElementById("bootstrap_theme").href = escape(theme_path);
+    document.documentElement.setAttribute('data-bs-theme','light')
   }
 
   const userInfoFields = [
@@ -975,7 +991,7 @@ update_chat = function (obj) {
         <img class="w-100 rounded-2" src="data:image/png;base64,${FD.atob(
           obj._attachments[filename]["data"]
         )}">
-       <p class="text-right mb-0 p-1 text-black" style="text-align: right; font-size : 1rem">
+       <p class="text-right mb-0 p-1" style="text-align: right; font-size : 1rem">
                     <span class="p-1" style="text-align: right; font-size : 0.8rem">${filename}</span>
                     <span class="p-1" style="text-align: right; font-size : 0.8rem">${filesize}</span>
                             <i class="bi bi-filetype-${filetype}" style="font-size: 2rem;"></i>
@@ -986,7 +1002,7 @@ update_chat = function (obj) {
       } else {
         var fileheader = `
         <div class="card-header border-0 bg-transparent text-end p-0 mb-0 hover-overlay">
-       <p class="text-right mb-0 p-1 text-black" style="text-align: right; font-size : 1rem">
+       <p class="text-right mb-0 p-1" style="text-align: right; font-size : 1rem">
                     <span class="p-1" style="text-align: right; font-size : 0.8rem">${filename}</span>
                     <span class="p-1" style="text-align: right; font-size : 0.8rem">${filesize}</span>
                             <i class="bi bi-filetype-${filetype}" style="font-size: 2rem;"></i>

--- a/gui/preload-chat.js
+++ b/gui/preload-chat.js
@@ -162,32 +162,32 @@ window.addEventListener("DOMContentLoaded", () => {
     document.getElementById("bootstrap_theme").href = escape(theme_path);
     document.querySelector("html").setAttribute("data-bs-theme", "dark");
   } else if (config.theme == "default_auto") {
-
     var theme_path = "../node_modules/bootstrap/dist/css/bootstrap.min.css";
-        document.getElementById("bootstrap_theme").href = escape(theme_path);
+    document.getElementById("bootstrap_theme").href = escape(theme_path);
 
-        // https://stackoverflow.com/a/57795495
-        // check if dark mode or light mode used in OS
-        if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
-        // dark mode
-            document.documentElement.setAttribute("data-bs-theme", "dark");
-        } else {
-            document.documentElement.setAttribute("data-bs-theme", "light");
-        }
+    // https://stackoverflow.com/a/57795495
+    // check if dark mode or light mode used in OS
+    if (
+      window.matchMedia &&
+      window.matchMedia("(prefers-color-scheme: dark)").matches
+    ) {
+      // dark mode
+      document.documentElement.setAttribute("data-bs-theme", "dark");
+    } else {
+      document.documentElement.setAttribute("data-bs-theme", "light");
+    }
 
-        // also register event listener for automatic change
-        window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', event => {
+    // also register event listener for automatic change
+    window
+      .matchMedia("(prefers-color-scheme: dark)")
+      .addEventListener("change", (event) => {
         let newColorScheme = event.matches ? "dark" : "light";
-        if(newColorScheme == "dark"){
-            document.documentElement.setAttribute("data-bs-theme", "dark");
+        if (newColorScheme == "dark") {
+          document.documentElement.setAttribute("data-bs-theme", "dark");
         } else {
-            document.documentElement.setAttribute("data-bs-theme", "light");
+          document.documentElement.setAttribute("data-bs-theme", "light");
         }
-
-        });
-
-
-
+      });
   } else {
     var theme_path = "../node_modules/bootstrap/dist/css/bootstrap.min.css";
     document.getElementById("bootstrap_theme").href = escape(theme_path);

--- a/gui/preload-chat.js
+++ b/gui/preload-chat.js
@@ -144,29 +144,30 @@ updateAllChat(false);
 // WINDOW LISTENER
 window.addEventListener("DOMContentLoaded", () => {
   // theme selector
-  if (config.theme != "default" && config.theme != "default_light" && config.theme != "default_dark" && config.theme != "default_auto") {
+  if (
+    config.theme != "default" &&
+    config.theme != "default_light" &&
+    config.theme != "default_dark" &&
+    config.theme != "default_auto"
+  ) {
     var theme_path =
       "../node_modules/bootswatch/dist/" + config.theme + "/bootstrap.min.css";
     document.getElementById("bootstrap_theme").href = escape(theme_path);
-
-  } else if (config.theme == "default" || config.theme == "default_light"){
+  } else if (config.theme == "default" || config.theme == "default_light") {
     var theme_path = "../node_modules/bootstrap/dist/css/bootstrap.min.css";
     document.getElementById("bootstrap_theme").href = escape(theme_path);
-    document.documentElement.setAttribute('data-bs-theme','light')
-
+    document.documentElement.setAttribute("data-bs-theme", "light");
   } else if (config.theme == "default_dark") {
     var theme_path = "../node_modules/bootstrap/dist/css/bootstrap.min.css";
     document.getElementById("bootstrap_theme").href = escape(theme_path);
-    document.querySelector("html").setAttribute('data-bs-theme','dark')
-
+    document.querySelector("html").setAttribute("data-bs-theme", "dark");
   } else if (config.theme == "default_auto") {
     var theme_path = "../node_modules/bootstrap/dist/css/bootstrap.min.css";
     document.getElementById("bootstrap_theme").href = escape(theme_path);
-
   } else {
     var theme_path = "../node_modules/bootstrap/dist/css/bootstrap.min.css";
     document.getElementById("bootstrap_theme").href = escape(theme_path);
-    document.documentElement.setAttribute('data-bs-theme','light')
+    document.documentElement.setAttribute("data-bs-theme", "light");
   }
 
   const userInfoFields = [

--- a/gui/preload-chat.js
+++ b/gui/preload-chat.js
@@ -991,9 +991,9 @@ update_chat = function (obj) {
 
       var controlarea_transmit = `
         <div class="ms-auto" id="msg-${obj._id}-control-area">
-                <button class="btn bg-transparent p-1 m-1"><i class="bi bi-arrow-repeat" id="retransmit-msg-${obj._id}" style="font-size: 1.2rem;"></i></button>
-                <button class="btn bg-transparent p-1 m-1"><i class="bi bi-download" id="save-file-msg-${obj._id}" style="font-size: 1.2rem;"></i></button>
-                <button class="btn bg-transparent p-1 m-1"><i class="bi bi-trash" id="del-msg-${obj._id}" style="font-size: 1.2rem;"></i></button>
+                <button class="btn bg-transparent p-1 m-1"><i class="bi bi-arrow-repeat link-secondary" id="retransmit-msg-${obj._id}" style="font-size: 1.2rem;"></i></button>
+                <button class="btn bg-transparent p-1 m-1"><i class="bi bi-download link-secondary" id="save-file-msg-${obj._id}" style="font-size: 1.2rem;"></i></button>
+                <button class="btn bg-transparent p-1 m-1"><i class="bi bi-trash link-secondary" id="del-msg-${obj._id}" style="font-size: 1.2rem;"></i></button>
              </div>
 
         `;
@@ -1001,8 +1001,8 @@ update_chat = function (obj) {
       var controlarea_receive = `
 
              <div class="me-auto" id="msg-${obj._id}-control-area">
-                <button class="btn bg-transparent p-1 m-1"><i class="bi bi-download" id="save-file-msg-${obj._id}" style="font-size: 1.2rem;"></i></button>
-                <button class="btn bg-transparent p-1 m-1"><i class="bi bi-trash" id="del-msg-${obj._id}" style="font-size: 1.2rem;"></i></button>
+                <button class="btn bg-transparent p-1 m-1"><i class="bi bi-download link-secondary" id="save-file-msg-${obj._id}" style="font-size: 1.2rem;"></i></button>
+                <button class="btn bg-transparent p-1 m-1"><i class="bi bi-trash link-secondary" id="del-msg-${obj._id}" style="font-size: 1.2rem;"></i></button>
              </div>
 
         `;
@@ -1012,13 +1012,13 @@ update_chat = function (obj) {
       var filetype = "text/plain";
       var controlarea_transmit = `
 <div class="ms-auto" id="msg-${obj._id}-control-area">
-                <button class="btn bg-transparent p-1 m-1"><i class="bi bi-arrow-repeat" id="retransmit-msg-${obj._id}" style="font-size: 1.2rem;"></i></button>
-                <button class="btn bg-transparent p-1 m-1"><i class="bi bi-trash" id="del-msg-${obj._id}" style="font-size: 1.2rem;"></i></button>
+                <button class="btn bg-transparent p-1 m-1"><i class="bi bi-arrow-repeat link-secondary" id="retransmit-msg-${obj._id}" style="font-size: 1.2rem;"></i></button>
+                <button class="btn bg-transparent p-1 m-1"><i class="bi bi-trash link-secondary" id="del-msg-${obj._id}" style="font-size: 1.2rem;"></i></button>
              </div>
         `;
       var controlarea_receive = `
       <div class="float-start" id="msg-${obj._id}-control-area">
-                      <button class="btn bg-transparent p-1 m-1"><i class="bi bi-trash" id="del-msg-${obj._id}" style="font-size: 1.2rem;"></i></button>
+                      <button class="btn bg-transparent p-1 m-1"><i class="bi bi-trash link-secondary" id="del-msg-${obj._id}" style="font-size: 1.2rem;"></i></button>
                    </div>
               `;
     }

--- a/gui/preload-main.js
+++ b/gui/preload-main.js
@@ -338,44 +338,39 @@ window.addEventListener("DOMContentLoaded", () => {
   }
   // theme selector
 
-  if (config.theme != "default" && config.theme != "default_light" && config.theme != "default_dark" && config.theme != "default_auto") {
+  if (
+    config.theme != "default" &&
+    config.theme != "default_light" &&
+    config.theme != "default_dark" &&
+    config.theme != "default_auto"
+  ) {
     var theme_path =
       "../node_modules/bootswatch/dist/" + config.theme + "/bootstrap.min.css";
     document.getElementById("theme_selector").value = config.theme;
     document.getElementById("bootstrap_theme").href = escape(theme_path);
-
-  } else if (config.theme == "default" || config.theme == "default_light"){
+  } else if (config.theme == "default" || config.theme == "default_light") {
     var theme_path = "../node_modules/bootstrap/dist/css/bootstrap.min.css";
     document.getElementById("theme_selector").value = "default_light";
     document.getElementById("bootstrap_theme").href = escape(theme_path);
 
-    document.documentElement.setAttribute('data-bs-theme','light')
-
+    document.documentElement.setAttribute("data-bs-theme", "light");
   } else if (config.theme == "default_dark") {
     var theme_path = "../node_modules/bootstrap/dist/css/bootstrap.min.css";
     document.getElementById("theme_selector").value = "default_dark";
     document.getElementById("bootstrap_theme").href = escape(theme_path);
 
-    document.querySelector("html").setAttribute('data-bs-theme','dark')
-
+    document.querySelector("html").setAttribute("data-bs-theme", "dark");
   } else if (config.theme == "default_auto") {
     var theme_path = "../node_modules/bootstrap/dist/css/bootstrap.min.css";
     document.getElementById("theme_selector").value = "default_auto";
     document.getElementById("bootstrap_theme").href = escape(theme_path);
-
   } else {
     var theme_path = "../node_modules/bootstrap/dist/css/bootstrap.min.css";
     document.getElementById("theme_selector").value = "default_light";
     document.getElementById("bootstrap_theme").href = escape(theme_path);
 
-    document.documentElement.setAttribute('data-bs-theme','light')
+    document.documentElement.setAttribute("data-bs-theme", "light");
   }
-
-
-
-
-
-
 
   // Update channel selector
   document.getElementById("update_channel_selector").value =
@@ -1191,7 +1186,7 @@ window.addEventListener("DOMContentLoaded", () => {
   // Theme selector clicked
 
   document.getElementById("theme_selector").addEventListener("change", () => {
-/*
+    /*
     var theme = document.getElementById("theme_selector").value;
     if (theme != "default") {
       var theme_path =
@@ -1200,36 +1195,30 @@ window.addEventListener("DOMContentLoaded", () => {
       var theme_path = "../node_modules/bootstrap/dist/css/bootstrap.min.css";
     }
 */
-var theme = document.getElementById("theme_selector").value;
-if (theme != "default" && theme != "default_light" && theme != "default_dark" && theme != "default_auto") {
-     var theme_path =
+    var theme = document.getElementById("theme_selector").value;
+    if (
+      theme != "default" &&
+      theme != "default_light" &&
+      theme != "default_dark" &&
+      theme != "default_auto"
+    ) {
+      var theme_path =
         "../node_modules/bootswatch/dist/" + theme + "/bootstrap.min.css";
+    } else if (theme == "default" || theme == "default_light") {
+      var theme_path = "../node_modules/bootstrap/dist/css/bootstrap.min.css";
 
-  } else if (theme == "default" || theme == "default_light"){
-    var theme_path = "../node_modules/bootstrap/dist/css/bootstrap.min.css";
+      document.documentElement.setAttribute("data-bs-theme", "light");
+    } else if (theme == "default_dark") {
+      var theme_path = "../node_modules/bootstrap/dist/css/bootstrap.min.css";
 
-    document.documentElement.setAttribute('data-bs-theme','light')
+      document.querySelector("html").setAttribute("data-bs-theme", "dark");
+    } else if (theme == "default_auto") {
+      var theme_path = "../node_modules/bootstrap/dist/css/bootstrap.min.css";
+    } else {
+      var theme_path = "../node_modules/bootstrap/dist/css/bootstrap.min.css";
 
-  } else if (theme == "default_dark") {
-    var theme_path = "../node_modules/bootstrap/dist/css/bootstrap.min.css";
-
-    document.querySelector("html").setAttribute('data-bs-theme','dark')
-
-  } else if (theme == "default_auto") {
-    var theme_path = "../node_modules/bootstrap/dist/css/bootstrap.min.css";
-
-  } else {
-    var theme_path = "../node_modules/bootstrap/dist/css/bootstrap.min.css";
-
-    document.documentElement.setAttribute('data-bs-theme','light')
-  }
-
-
-
-
-
-
-
+      document.documentElement.setAttribute("data-bs-theme", "light");
+    }
 
     //update path to css file
     document.getElementById("bootstrap_theme").href = escape(theme_path);

--- a/gui/preload-main.js
+++ b/gui/preload-main.js
@@ -337,64 +337,7 @@ window.addEventListener("DOMContentLoaded", () => {
     document.getElementById("autoTuneSwitch").checked = false;
   }
   // theme selector
-
-  if (
-    config.theme != "default" &&
-    config.theme != "default_light" &&
-    config.theme != "default_dark" &&
-    config.theme != "default_auto"
-  ) {
-    var theme_path =
-      "../node_modules/bootswatch/dist/" + config.theme + "/bootstrap.min.css";
-    document.getElementById("theme_selector").value = config.theme;
-    document.getElementById("bootstrap_theme").href = escape(theme_path);
-  } else if (config.theme == "default" || config.theme == "default_light") {
-    var theme_path = "../node_modules/bootstrap/dist/css/bootstrap.min.css";
-    document.getElementById("theme_selector").value = "default_light";
-    document.getElementById("bootstrap_theme").href = escape(theme_path);
-
-    document.documentElement.setAttribute("data-bs-theme", "light");
-  } else if (config.theme == "default_dark") {
-    var theme_path = "../node_modules/bootstrap/dist/css/bootstrap.min.css";
-    document.getElementById("theme_selector").value = "default_dark";
-    document.getElementById("bootstrap_theme").href = escape(theme_path);
-
-    document.querySelector("html").setAttribute("data-bs-theme", "dark");
-  } else if (config.theme == "default_auto") {
-    var theme_path = "../node_modules/bootstrap/dist/css/bootstrap.min.css";
-    document.getElementById("theme_selector").value = "default_auto";
-    document.getElementById("bootstrap_theme").href = escape(theme_path);
-
-    // https://stackoverflow.com/a/57795495
-    // check if dark mode or light mode used in OS
-    if (
-      window.matchMedia &&
-      window.matchMedia("(prefers-color-scheme: dark)").matches
-    ) {
-      // dark mode
-      document.documentElement.setAttribute("data-bs-theme", "dark");
-    } else {
-      document.documentElement.setAttribute("data-bs-theme", "light");
-    }
-
-    // also register event listener for automatic change
-    window
-      .matchMedia("(prefers-color-scheme: dark)")
-      .addEventListener("change", (event) => {
-        let newColorScheme = event.matches ? "dark" : "light";
-        if (newColorScheme == "dark") {
-          document.documentElement.setAttribute("data-bs-theme", "dark");
-        } else {
-          document.documentElement.setAttribute("data-bs-theme", "light");
-        }
-      });
-  } else {
-    var theme_path = "../node_modules/bootstrap/dist/css/bootstrap.min.css";
-    document.getElementById("theme_selector").value = "default_light";
-    document.getElementById("bootstrap_theme").href = escape(theme_path);
-
-    document.documentElement.setAttribute("data-bs-theme", "light");
-  }
+  changeGuiDesign(config.theme)
 
   // Update channel selector
   document.getElementById("update_channel_selector").value =
@@ -1220,56 +1163,7 @@ window.addEventListener("DOMContentLoaded", () => {
     }
 */
     var theme = document.getElementById("theme_selector").value;
-    if (
-      theme != "default" &&
-      theme != "default_light" &&
-      theme != "default_dark" &&
-      theme != "default_auto"
-    ) {
-      var theme_path =
-        "../node_modules/bootswatch/dist/" + theme + "/bootstrap.min.css";
-    } else if (theme == "default" || theme == "default_light") {
-      var theme_path = "../node_modules/bootstrap/dist/css/bootstrap.min.css";
-
-      document.documentElement.setAttribute("data-bs-theme", "light");
-    } else if (theme == "default_dark") {
-      var theme_path = "../node_modules/bootstrap/dist/css/bootstrap.min.css";
-
-      document.querySelector("html").setAttribute("data-bs-theme", "dark");
-    } else if (theme == "default_auto") {
-      var theme_path = "../node_modules/bootstrap/dist/css/bootstrap.min.css";
-      // https://stackoverflow.com/a/57795495
-      // check if dark mode or light mode used in OS
-      if (
-        window.matchMedia &&
-        window.matchMedia("(prefers-color-scheme: dark)").matches
-      ) {
-        // dark mode
-        document.documentElement.setAttribute("data-bs-theme", "dark");
-      } else {
-        document.documentElement.setAttribute("data-bs-theme", "light");
-      }
-
-      // also register event listener for automatic change
-      window
-        .matchMedia("(prefers-color-scheme: dark)")
-        .addEventListener("change", (event) => {
-          let newColorScheme = event.matches ? "dark" : "light";
-          if (newColorScheme == "dark") {
-            document.documentElement.setAttribute("data-bs-theme", "dark");
-          } else {
-            document.documentElement.setAttribute("data-bs-theme", "light");
-          }
-        });
-    } else {
-      var theme_path = "../node_modules/bootstrap/dist/css/bootstrap.min.css";
-
-      document.documentElement.setAttribute("data-bs-theme", "light");
-    }
-
-    //update path to css file
-    document.getElementById("bootstrap_theme").href = escape(theme_path);
-
+    changeGuiDesign(theme);
     config.theme = theme;
     //fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
     FD.saveConfig(config, configPath);
@@ -3464,4 +3358,73 @@ function loadSettings(elements) {
   ipcRenderer.on("update-config", (event, data) => {
     config = data;
   });
+}
+
+
+
+function changeGuiDesign(design){
+
+  if (
+    design != "default" &&
+    design != "default_light" &&
+    design != "default_dark" &&
+    design != "default_auto"
+  ) {
+    var theme_path =
+      "../node_modules/bootswatch/dist/" + design + "/bootstrap.min.css";
+    document.getElementById("theme_selector").value = design;
+    document.getElementById("bootstrap_theme").href = escape(theme_path);
+  } else if (design == "default" || design == "default_light") {
+    var theme_path = "../node_modules/bootstrap/dist/css/bootstrap.min.css";
+    document.getElementById("theme_selector").value = "default_light";
+    document.getElementById("bootstrap_theme").href = escape(theme_path);
+
+    document.documentElement.setAttribute("data-bs-theme", "light");
+  } else if (design == "default_dark") {
+    var theme_path = "../node_modules/bootstrap/dist/css/bootstrap.min.css";
+    document.getElementById("theme_selector").value = "default_dark";
+    document.getElementById("bootstrap_theme").href = escape(theme_path);
+
+    document.querySelector("html").setAttribute("data-bs-theme", "dark");
+  } else if (design == "default_auto") {
+    var theme_path = "../node_modules/bootstrap/dist/css/bootstrap.min.css";
+    document.getElementById("theme_selector").value = "default_auto";
+    document.getElementById("bootstrap_theme").href = escape(theme_path);
+
+    // https://stackoverflow.com/a/57795495
+    // check if dark mode or light mode used in OS
+    if (
+      window.matchMedia &&
+      window.matchMedia("(prefers-color-scheme: dark)").matches
+    ) {
+      // dark mode
+      document.documentElement.setAttribute("data-bs-theme", "dark");
+    } else {
+      document.documentElement.setAttribute("data-bs-theme", "light");
+    }
+
+    // also register event listener for automatic change
+    window
+      .matchMedia("(prefers-color-scheme: dark)")
+      .addEventListener("change", (event) => {
+        let newColorScheme = event.matches ? "dark" : "light";
+        if (newColorScheme == "dark") {
+          document.documentElement.setAttribute("data-bs-theme", "dark");
+        } else {
+          document.documentElement.setAttribute("data-bs-theme", "light");
+        }
+      });
+  } else {
+    var theme_path = "../node_modules/bootstrap/dist/css/bootstrap.min.css";
+    document.getElementById("theme_selector").value = "default_light";
+    document.getElementById("bootstrap_theme").href = escape(theme_path);
+
+    document.documentElement.setAttribute("data-bs-theme", "light");
+  }
+
+  //update path to css file
+    document.getElementById("bootstrap_theme").href = escape(theme_path);
+
+
+
 }

--- a/gui/preload-main.js
+++ b/gui/preload-main.js
@@ -337,7 +337,7 @@ window.addEventListener("DOMContentLoaded", () => {
     document.getElementById("autoTuneSwitch").checked = false;
   }
   // theme selector
-  changeGuiDesign(config.theme)
+  changeGuiDesign(config.theme);
 
   // Update channel selector
   document.getElementById("update_channel_selector").value =
@@ -3360,10 +3360,7 @@ function loadSettings(elements) {
   });
 }
 
-
-
-function changeGuiDesign(design){
-
+function changeGuiDesign(design) {
   if (
     design != "default" &&
     design != "default_light" &&
@@ -3423,8 +3420,5 @@ function changeGuiDesign(design){
   }
 
   //update path to css file
-    document.getElementById("bootstrap_theme").href = escape(theme_path);
-
-
-
+  document.getElementById("bootstrap_theme").href = escape(theme_path);
 }

--- a/gui/preload-main.js
+++ b/gui/preload-main.js
@@ -338,16 +338,44 @@ window.addEventListener("DOMContentLoaded", () => {
   }
   // theme selector
 
-  if (config.theme != "default") {
+  if (config.theme != "default" && config.theme != "default_light" && config.theme != "default_dark" && config.theme != "default_auto") {
     var theme_path =
       "../node_modules/bootswatch/dist/" + config.theme + "/bootstrap.min.css";
     document.getElementById("theme_selector").value = config.theme;
     document.getElementById("bootstrap_theme").href = escape(theme_path);
+
+  } else if (config.theme == "default" || config.theme == "default_light"){
+    var theme_path = "../node_modules/bootstrap/dist/css/bootstrap.min.css";
+    document.getElementById("theme_selector").value = "default_light";
+    document.getElementById("bootstrap_theme").href = escape(theme_path);
+
+    document.documentElement.setAttribute('data-bs-theme','light')
+
+  } else if (config.theme == "default_dark") {
+    var theme_path = "../node_modules/bootstrap/dist/css/bootstrap.min.css";
+    document.getElementById("theme_selector").value = "default_dark";
+    document.getElementById("bootstrap_theme").href = escape(theme_path);
+
+    document.querySelector("html").setAttribute('data-bs-theme','dark')
+
+  } else if (config.theme == "default_auto") {
+    var theme_path = "../node_modules/bootstrap/dist/css/bootstrap.min.css";
+    document.getElementById("theme_selector").value = "default_auto";
+    document.getElementById("bootstrap_theme").href = escape(theme_path);
+
   } else {
     var theme_path = "../node_modules/bootstrap/dist/css/bootstrap.min.css";
-    document.getElementById("theme_selector").value = "default";
+    document.getElementById("theme_selector").value = "default_light";
     document.getElementById("bootstrap_theme").href = escape(theme_path);
+
+    document.documentElement.setAttribute('data-bs-theme','light')
   }
+
+
+
+
+
+
 
   // Update channel selector
   document.getElementById("update_channel_selector").value =
@@ -1161,7 +1189,9 @@ window.addEventListener("DOMContentLoaded", () => {
   });
 
   // Theme selector clicked
+
   document.getElementById("theme_selector").addEventListener("change", () => {
+/*
     var theme = document.getElementById("theme_selector").value;
     if (theme != "default") {
       var theme_path =
@@ -1169,6 +1199,37 @@ window.addEventListener("DOMContentLoaded", () => {
     } else {
       var theme_path = "../node_modules/bootstrap/dist/css/bootstrap.min.css";
     }
+*/
+var theme = document.getElementById("theme_selector").value;
+if (theme != "default" && theme != "default_light" && theme != "default_dark" && theme != "default_auto") {
+     var theme_path =
+        "../node_modules/bootswatch/dist/" + theme + "/bootstrap.min.css";
+
+  } else if (theme == "default" || theme == "default_light"){
+    var theme_path = "../node_modules/bootstrap/dist/css/bootstrap.min.css";
+
+    document.documentElement.setAttribute('data-bs-theme','light')
+
+  } else if (theme == "default_dark") {
+    var theme_path = "../node_modules/bootstrap/dist/css/bootstrap.min.css";
+
+    document.querySelector("html").setAttribute('data-bs-theme','dark')
+
+  } else if (theme == "default_auto") {
+    var theme_path = "../node_modules/bootstrap/dist/css/bootstrap.min.css";
+
+  } else {
+    var theme_path = "../node_modules/bootstrap/dist/css/bootstrap.min.css";
+
+    document.documentElement.setAttribute('data-bs-theme','light')
+  }
+
+
+
+
+
+
+
 
     //update path to css file
     document.getElementById("bootstrap_theme").href = escape(theme_path);

--- a/gui/preload-main.js
+++ b/gui/preload-main.js
@@ -367,24 +367,27 @@ window.addEventListener("DOMContentLoaded", () => {
 
     // https://stackoverflow.com/a/57795495
     // check if dark mode or light mode used in OS
-    if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
-    // dark mode
-        document.documentElement.setAttribute("data-bs-theme", "dark");
+    if (
+      window.matchMedia &&
+      window.matchMedia("(prefers-color-scheme: dark)").matches
+    ) {
+      // dark mode
+      document.documentElement.setAttribute("data-bs-theme", "dark");
     } else {
-        document.documentElement.setAttribute("data-bs-theme", "light");
+      document.documentElement.setAttribute("data-bs-theme", "light");
     }
 
     // also register event listener for automatic change
-    window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', event => {
-    let newColorScheme = event.matches ? "dark" : "light";
-    if(newColorScheme == "dark"){
-    document.documentElement.setAttribute("data-bs-theme", "dark");
-    } else {
-    document.documentElement.setAttribute("data-bs-theme", "light");
-    }
-    });
-
-
+    window
+      .matchMedia("(prefers-color-scheme: dark)")
+      .addEventListener("change", (event) => {
+        let newColorScheme = event.matches ? "dark" : "light";
+        if (newColorScheme == "dark") {
+          document.documentElement.setAttribute("data-bs-theme", "dark");
+        } else {
+          document.documentElement.setAttribute("data-bs-theme", "light");
+        }
+      });
   } else {
     var theme_path = "../node_modules/bootstrap/dist/css/bootstrap.min.css";
     document.getElementById("theme_selector").value = "default_light";
@@ -1235,27 +1238,29 @@ window.addEventListener("DOMContentLoaded", () => {
       document.querySelector("html").setAttribute("data-bs-theme", "dark");
     } else if (theme == "default_auto") {
       var theme_path = "../node_modules/bootstrap/dist/css/bootstrap.min.css";
-        // https://stackoverflow.com/a/57795495
-        // check if dark mode or light mode used in OS
-        if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      // https://stackoverflow.com/a/57795495
+      // check if dark mode or light mode used in OS
+      if (
+        window.matchMedia &&
+        window.matchMedia("(prefers-color-scheme: dark)").matches
+      ) {
         // dark mode
+        document.documentElement.setAttribute("data-bs-theme", "dark");
+      } else {
+        document.documentElement.setAttribute("data-bs-theme", "light");
+      }
+
+      // also register event listener for automatic change
+      window
+        .matchMedia("(prefers-color-scheme: dark)")
+        .addEventListener("change", (event) => {
+          let newColorScheme = event.matches ? "dark" : "light";
+          if (newColorScheme == "dark") {
             document.documentElement.setAttribute("data-bs-theme", "dark");
-        } else {
+          } else {
             document.documentElement.setAttribute("data-bs-theme", "light");
-        }
-
-        // also register event listener for automatic change
-        window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', event => {
-        let newColorScheme = event.matches ? "dark" : "light";
-        if(newColorScheme == "dark"){
-    document.documentElement.setAttribute("data-bs-theme", "dark");
-    } else {
-    document.documentElement.setAttribute("data-bs-theme", "light");
-    }
+          }
         });
-
-
-
     } else {
       var theme_path = "../node_modules/bootstrap/dist/css/bootstrap.min.css";
 

--- a/gui/preload-main.js
+++ b/gui/preload-main.js
@@ -364,6 +364,27 @@ window.addEventListener("DOMContentLoaded", () => {
     var theme_path = "../node_modules/bootstrap/dist/css/bootstrap.min.css";
     document.getElementById("theme_selector").value = "default_auto";
     document.getElementById("bootstrap_theme").href = escape(theme_path);
+
+    // https://stackoverflow.com/a/57795495
+    // check if dark mode or light mode used in OS
+    if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+    // dark mode
+        document.documentElement.setAttribute("data-bs-theme", "dark");
+    } else {
+        document.documentElement.setAttribute("data-bs-theme", "light");
+    }
+
+    // also register event listener for automatic change
+    window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', event => {
+    let newColorScheme = event.matches ? "dark" : "light";
+    if(newColorScheme == "dark"){
+    document.documentElement.setAttribute("data-bs-theme", "dark");
+    } else {
+    document.documentElement.setAttribute("data-bs-theme", "light");
+    }
+    });
+
+
   } else {
     var theme_path = "../node_modules/bootstrap/dist/css/bootstrap.min.css";
     document.getElementById("theme_selector").value = "default_light";
@@ -1214,6 +1235,27 @@ window.addEventListener("DOMContentLoaded", () => {
       document.querySelector("html").setAttribute("data-bs-theme", "dark");
     } else if (theme == "default_auto") {
       var theme_path = "../node_modules/bootstrap/dist/css/bootstrap.min.css";
+        // https://stackoverflow.com/a/57795495
+        // check if dark mode or light mode used in OS
+        if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+        // dark mode
+            document.documentElement.setAttribute("data-bs-theme", "dark");
+        } else {
+            document.documentElement.setAttribute("data-bs-theme", "light");
+        }
+
+        // also register event listener for automatic change
+        window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', event => {
+        let newColorScheme = event.matches ? "dark" : "light";
+        if(newColorScheme == "dark"){
+    document.documentElement.setAttribute("data-bs-theme", "dark");
+    } else {
+    document.documentElement.setAttribute("data-bs-theme", "light");
+    }
+        });
+
+
+
     } else {
       var theme_path = "../node_modules/bootstrap/dist/css/bootstrap.min.css";
 

--- a/gui/src/chat-module.html
+++ b/gui/src/chat-module.html
@@ -288,7 +288,7 @@
                 <i
                   id="emojipickerbutton"
                   class="bi bi-emoji-smile p-0"
-                  style="font-size: 1rem;"
+                  style="font-size: 1rem"
                 ></i>
               </div>
 
@@ -302,7 +302,7 @@
               <div class="input-group-text me-3">
                 <i
                   class="bi bi-paperclip"
-                  style="font-size: 1rem;"
+                  style="font-size: 1rem"
                   id="selectFilesButton"
                 ></i>
 
@@ -311,10 +311,7 @@
                   id="sendMessage"
                   type="button"
                 >
-                  <i
-                    class="bi bi-send"
-                    style="font-size: 1.2rem;"
-                  ></i>
+                  <i class="bi bi-send" style="font-size: 1.2rem"></i>
                 </button>
               </div>
             </div>

--- a/gui/src/chat-module.html
+++ b/gui/src/chat-module.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-bs-theme="light">
   <head>
     <!-- Required meta tags -->
     <meta charset="utf-8" />
@@ -48,7 +48,7 @@
     </div>
     <div class="container-fluid">
       <div class="row h-100">
-        <div class="col-4 p-2 bg-light">
+        <div class="col-4 p-2">
           <! ------Chats area ---------------------------------------------------------------------->
           <div class="container-fluid m-0 p-0">
             <div class="input-group bottom-0 m-0 w-100">
@@ -284,11 +284,11 @@
             <div class="input-group bottom-0 ms-2">
               <!--<input class="form-control" maxlength="8" style="max-width: 6rem; text-transform:uppercase; display:none" id="chatModuleDxCall" placeholder="DX CALL"></input>-->
               <!--<button class="btn btn-sm btn-primary me-2" id="emojipickerbutton" type="button">-->
-              <div class="input-group-text bg-white">
+              <div class="input-group-text">
                 <i
                   id="emojipickerbutton"
                   class="bi bi-emoji-smile p-0"
-                  style="font-size: 1rem; color: grey"
+                  style="font-size: 1rem;"
                 ></i>
               </div>
 
@@ -299,10 +299,10 @@
                 placeholder="Message - Send with [Enter]"
               ></textarea>
 
-              <div class="input-group-text bg-white me-3">
+              <div class="input-group-text me-3">
                 <i
                   class="bi bi-paperclip"
-                  style="font-size: 1rem; color: grey"
+                  style="font-size: 1rem;"
                   id="selectFilesButton"
                 ></i>
 
@@ -313,7 +313,7 @@
                 >
                   <i
                     class="bi bi-send"
-                    style="font-size: 1.2rem; color: white"
+                    style="font-size: 1.2rem;"
                   ></i>
                 </button>
               </div>
@@ -346,7 +346,7 @@
                     />
                   </div>
                   <div
-                    class="col position-absolute image-overlay text-white justify-content-center align-items-center d-flex align-middle h-100 bg-dark opacity-0"
+                    class="col position-absolute image-overlay text-white justify-content-center align-items-center d-flex align-middle h-100 opacity-0"
                     id="userImageSelector"
                   >
                     <i class="bi bi-upload" style="font-size: 2.2rem"></i>

--- a/gui/src/index.html
+++ b/gui/src/index.html
@@ -102,10 +102,7 @@
               type="button"
               disabled
             >
-              <i
-                class="bi bi-diagram-3"
-                style="font-size: 1rem;"
-              ></i>
+              <i class="bi bi-diagram-3" style="font-size: 1rem"></i>
             </button>
           </div>
         </div>
@@ -273,30 +270,18 @@
       <div class="container p-0" style="margin-top: 55px">
         <div class="row collapse multi-collapse show" id="collapseFirstRow">
           <div class="col">
-            <div class="card mb-0 ">
-              <div class="card-header p-2 ">
+            <div class="card mb-0">
+              <div class="card-header p-2">
                 <div class="">
-                <i
-                  class="bi bi-volume-up"
-                  style="font-size: 1rem;"
-                ></i
-                ><strong>AUDIO</strong>
-
-                  </div>
+                  <i class="bi bi-volume-up" style="font-size: 1rem"></i
+                  ><strong>AUDIO</strong>
+                </div>
               </div>
 
-
-
-
-
-
-              <div class="card-body p-1" style="height:100px">
+              <div class="card-body p-1" style="height: 100px">
                 <div class="input-group input-group-sm mb-1">
-                  <span class="input-group-text ">
-                    <i
-                      class="bi bi-mic-fill"
-                      style="font-size: 1rem;"
-                    ></i>
+                  <span class="input-group-text">
+                    <i class="bi bi-mic-fill" style="font-size: 1rem"></i>
                   </span>
                   <select
                     class="form-select form-select-sm"
@@ -307,11 +292,8 @@
                   </select>
                 </div>
                 <div class="input-group input-group-sm mb-1">
-                  <span class="input-group-text ">
-                    <i
-                      class="bi bi-volume-up"
-                      style="font-size: 1rem;"
-                    ></i>
+                  <span class="input-group-text">
+                    <i class="bi bi-volume-up" style="font-size: 1rem"></i>
                   </span>
                   <select
                     class="form-select form-select-sm"
@@ -320,19 +302,16 @@
                   ></select>
                 </div>
               </div>
-              <div class="card-footer text-muted small ">
+              <div class="card-footer text-muted small">
                 Please select audio device for RX and TX
               </div>
             </div>
             <!--Start of TNC rig control pane-->
           </div>
           <div class="col">
-            <div class="card mb-0  ">
-              <div class="card-header p-1 ">
-                <i
-                  class="bi bi-projector"
-                  style="font-size: 1rem;"
-                ></i
+            <div class="card mb-0">
+              <div class="card-header p-1">
+                <i class="bi bi-projector" style="font-size: 1rem"></i
                 ><strong> TNC RIG CONTROL</strong>
                 <div
                   class="btn-group btn-group-sm"
@@ -393,7 +372,7 @@
                   </label>
                 </div>
               </div>
-              <div class="card-body p-2" style="height:100px">
+              <div class="card-body p-2" style="height: 100px">
                 <!-- RADIO CONTROL DISABLED -->
                 <div id="radio-control-disabled">
                   <p class="small">
@@ -407,10 +386,10 @@
                 <div id="radio-control-rigctld">
                   <div class="input-group input-group-sm mb-1">
                     <div class="input-group input-group-sm mb-1">
-                      <span class="input-group-text "
+                      <span class="input-group-text"
                         >Rigctld Network settings</span
                       >
-                      <span class="input-group-text ">IP</span>
+                      <span class="input-group-text">IP</span>
                       <input
                         type="text"
                         class="form-control"
@@ -419,7 +398,7 @@
                         aria-label="Device IP"
                         aria-describedby="basic-addon1"
                       />
-                      <span class="input-group-text ">Port</span>
+                      <span class="input-group-text">Port</span>
                       <input
                         type="text"
                         class="form-control"
@@ -431,44 +410,44 @@
                     </div>
 
                     <div class="input-group input-group-sm mb-1">
-                    <span class="input-group-text ">Rigctld application</span>
-                    <button
-                      class="btn btn-outline-success"
-                      type="button"
-                      id="hamlib_rigctld_start"
-                    >
-                      Start
-                    </button>
-                    <input
-                      type="text"
-                      class="form-control"
-                      placeholder="Status"
-                      id="hamlib_rigctld_status"
-                      aria-label="State"
-                      aria-describedby="basic-addon1"
-                    />
-                    <button
-                      class="btn btn-outline-danger"
-                      type="button"
-                      id="hamlib_rigctld_stop"
-                    >
-                      Stop
-                    </button>
-                    <button
-                      type="button"
-                      id="testHamlib"
-                      class="btn btn-sm btn-outline-secondary ms-1"
-                      data-bs-placement="bottom"
-                      data-bs-toggle="tooltip"
-                      data-bs-trigger="hover"
-                      data-bs-html="true"
-                      title="Test your hamlib settings and toggle PTT once. Button will become <strong class='text-success'>green</strong> on success and <strong class='text-danger'>red</strong> if fails."
-                    >
-                      PTT Test
-                    </button>
+                      <span class="input-group-text">Rigctld application</span>
+                      <button
+                        class="btn btn-outline-success"
+                        type="button"
+                        id="hamlib_rigctld_start"
+                      >
+                        Start
+                      </button>
+                      <input
+                        type="text"
+                        class="form-control"
+                        placeholder="Status"
+                        id="hamlib_rigctld_status"
+                        aria-label="State"
+                        aria-describedby="basic-addon1"
+                      />
+                      <button
+                        class="btn btn-outline-danger"
+                        type="button"
+                        id="hamlib_rigctld_stop"
+                      >
+                        Stop
+                      </button>
+                      <button
+                        type="button"
+                        id="testHamlib"
+                        class="btn btn-sm btn-outline-secondary ms-1"
+                        data-bs-placement="bottom"
+                        data-bs-toggle="tooltip"
+                        data-bs-trigger="hover"
+                        data-bs-html="true"
+                        title="Test your hamlib settings and toggle PTT once. Button will become <strong class='text-success'>green</strong> on success and <strong class='text-danger'>red</strong> if fails."
+                      >
+                        PTT Test
+                      </button>
+                    </div>
                   </div>
                 </div>
-                  </div>
 
                 <!-- RADIO CONTROL HELP -->
                 <div id="radio-control-help">
@@ -481,7 +460,7 @@
                   happens automatically.
                 </div>
               </div>
-              <div class="card-footer text-muted small " id="hamlib_info_field">
+              <div class="card-footer text-muted small" id="hamlib_info_field">
                 Define TNC rig control mode (none/hamlib)
               </div>
             </div>
@@ -492,8 +471,10 @@
           id="collapseSecondRow"
         >
           <div class="col">
-            <div class="card mb-1  ">
-              <div class="card-header  p-2"><i class="bi bi-house-door"></i><strong> MY STATION</strong></div>
+            <div class="card mb-1">
+              <div class="card-header p-2">
+                <i class="bi bi-house-door"></i><strong> MY STATION</strong>
+              </div>
               <div class="card-body p-2">
                 <div class="row">
                   <div class="col-md-auto">
@@ -505,10 +486,10 @@
                       data-bs-html="false"
                       title="Enter your callsign and save it"
                     >
-                      <span class="input-group-text ">
+                      <span class="input-group-text">
                         <i
                           class="bi bi-person-bounding-box"
-                          style="font-size: 1rem;"
+                          style="font-size: 1rem"
                         ></i>
                       </span>
                       <input
@@ -555,11 +536,8 @@
                       data-bs-html="false"
                       title="Enter your gridsquare and save it"
                     >
-                      <span class="input-group-text ">
-                        <i
-                          class="bi bi-house-fill"
-                          style="font-size: 1rem;"
-                        ></i>
+                      <span class="input-group-text">
+                        <i class="bi bi-house-fill" style="font-size: 1rem"></i>
                       </span>
                       <input
                         type="text"
@@ -579,11 +557,11 @@
             </div>
           </div>
           <div class="col">
-            <div class="card mb-0  ">
-              <div class="card-header p-2  d-flex">
+            <div class="card mb-0">
+              <div class="card-header p-2 d-flex">
                 <i
                   class="bi bi-cloud-download ms-1 me-1"
-                  style="font-size: 1rem;"
+                  style="font-size: 1rem"
                 ></i>
                 <strong>UPDATER</strong>
                 <div class="progress w-75 ms-1 m-1">
@@ -641,12 +619,9 @@
       <div class="container mt-2 p-0">
         <div class="row collapse multi-collapse" id="collapseThirdRow">
           <div class="col-5">
-            <div class="card mb-1  ">
-              <div class="card-header p-1 ">
-                <i
-                  class="bi bi-volume-up"
-                  style="font-size: 1rem;"
-                ></i>
+            <div class="card mb-1">
+              <div class="card-header p-1">
+                <i class="bi bi-volume-up" style="font-size: 1rem"></i>
                 <strong>AUDIO LEVEL</strong>
                 <button
                   type="button"
@@ -780,8 +755,8 @@
             </div>
           </div>
           <div class="col">
-            <div class="card mb-1  ">
-              <div class="card-header p-2 ">
+            <div class="card mb-1">
+              <div class="card-header p-2">
                 <strong>PING, CQ & BEACON</strong>
               </div>
               <div class="card-body p-2">
@@ -890,8 +865,8 @@
         </div>
         <div class="row collapse multi-collapse" id="collapseFourthRow">
           <div class="col-5">
-            <div class="card mb-1  ">
-              <div class="card-header p-1 ">
+            <div class="card mb-1">
+              <div class="card-header p-1">
                 <div
                   class="btn-group btn-group-sm"
                   role="group"
@@ -987,12 +962,12 @@
             </div>
           </div>
           <div class="col">
-            <div class="card mb-1  " style="height: 240px">
+            <div class="card mb-1" style="height: 240px">
               <!--325px-->
-              <div class="card-header p-2 ">
+              <div class="card-header p-2">
                 <i
                   class="bi bi-list-columns-reverse"
-                  style="font-size: 1rem;"
+                  style="font-size: 1rem"
                 ></i>
                 <strong> HEARD STATIONS</strong>
               </div>
@@ -1045,10 +1020,7 @@
           id="openReceivedFilesFolder"
           type="button"
         >
-          <i
-            class="bi bi-folder2-open"
-            style="font-size: 1rem;"
-          ></i>
+          <i class="bi bi-folder2-open" style="font-size: 1rem"></i>
         </button>
         <h5 id="receivedFilesSidebarLabel">Filetransfer</h5>
         <button
@@ -1261,7 +1233,9 @@
     <!--end of blur div -->
     <!---------------------------------------------------------------------- FOOTER AREA ------------------------------------------------------------>
     <div class="container-fluid">
-      <nav class="navbar fixed-bottom navbar-expand-xl navbar-light  border-top rounded-3 p-2">
+      <nav
+        class="navbar fixed-bottom navbar-expand-xl navbar-light border-top rounded-3 p-2"
+      >
         <div class="col-sm-2">
           <div class="btn-toolbar" role="toolbar" style="margin-left: 2px">
             <div class="btn-group btn-group-sm me-1" role="group">
@@ -1275,10 +1249,7 @@
                 data-bs-html="true"
                 title="PTT state:<strong class='text-success'>RECEIVING</strong> / <strong class='text-danger'>TRANSMITTING</strong>"
               >
-                <i
-                  class="bi bi-broadcast-pin"
-                  style="font-size: 0.8rem;"
-                ></i>
+                <i class="bi bi-broadcast-pin" style="font-size: 0.8rem"></i>
               </button>
             </div>
             <div class="btn-group btn-group-sm me-1" role="group">
@@ -1292,10 +1263,7 @@
                 data-bs-html="true"
                 title="TNC busy state: <strong class='text-success'>IDLE</strong> / <strong class='text-danger'>BUSY</strong>"
               >
-                <i
-                  class="bi bi-cpu"
-                  style="font-size: 0.8rem;"
-                ></i>
+                <i class="bi bi-cpu" style="font-size: 0.8rem"></i>
               </button>
             </div>
             <div class="btn-group btn-group-sm me-1" role="group">
@@ -1309,10 +1277,7 @@
                 data-bs-html="true"
                 title="ARQ SESSION state: <strong class='text-warning'>OPEN</strong>"
               >
-                <i
-                  class="bi bi-arrow-left-right"
-                  style="font-size: 0.8rem;"
-                ></i>
+                <i class="bi bi-arrow-left-right" style="font-size: 0.8rem"></i>
               </button>
             </div>
             <div class="btn-group btn-group-sm me-1" role="group">
@@ -1328,7 +1293,7 @@
               >
                 <i
                   class="bi bi-file-earmark-binary"
-                  style="font-size: 0.8rem;"
+                  style="font-size: 0.8rem"
                 ></i>
               </button>
             </div>
@@ -1343,10 +1308,7 @@
                 data-bs-html="true"
                 title="rigctld state: <strong class='text-success'>CONNECTED</strong> / <strong class='text-secondary'>UNKNOWN</strong>"
               >
-                <i
-                  class="bi bi-usb-symbol"
-                  style="font-size: 0.8rem;"
-                ></i>
+                <i class="bi bi-usb-symbol" style="font-size: 0.8rem"></i>
               </button>
             </div>
           </div>
@@ -1387,10 +1349,7 @@
                     data-bs-html="false"
                     title="save frequency"
                   >
-                    <i
-                      class="bi bi-check-lg"
-                      style="font-size: 0.8rem;"
-                    ></i>
+                    <i class="bi bi-check-lg" style="font-size: 0.8rem"></i>
                   </button>
                 </div>
               </form>
@@ -1493,10 +1452,7 @@
         <div class="col-sm-3">
           <div class="input-group input-group-sm">
             <span class="input-group-text">
-              <i
-                class="bi bi-speedometer2"
-                style="font-size: 1rem;"
-              ></i>
+              <i class="bi bi-speedometer2" style="font-size: 1rem"></i>
             </span>
             <span
               class="input-group-text"
@@ -1509,14 +1465,11 @@
               <i
                 id="speed_level"
                 class="bi bi-reception-0"
-                style="font-size: 1rem;"
+                style="font-size: 1rem"
               ></i>
             </span>
             <span class="input-group-text">
-              <i
-                class="bi bi-file-earmark-binary"
-                style="font-size: 1rem;"
-              ></i>
+              <i class="bi bi-file-earmark-binary" style="font-size: 1rem"></i>
             </span>
             <span
               class="input-group-text"
@@ -1792,7 +1745,7 @@
                 </div>
                 <div class="input-group input-group-sm mb-1">
                   <label class="input-group-text w-50">Enable fancy GUI</label>
-                  <label class="input-group-text  w-50">
+                  <label class="input-group-text w-50">
                     <div class="form-check form-switch form-check-inline">
                       <input
                         class="form-check-input"
@@ -1839,7 +1792,7 @@
                   <label class="input-group-text w-50"
                     >Enable "is typing"</label
                   >
-                  <label class="input-group-text  w-50">
+                  <label class="input-group-text w-50">
                     <div class="form-check form-switch form-check-inline">
                       <input
                         class="form-check-input"
@@ -1857,7 +1810,7 @@
                   <label class="input-group-text w-50"
                     >Allow requesting "user profile"</label
                   >
-                  <label class="input-group-text  w-50">
+                  <label class="input-group-text w-50">
                     <div class="form-check form-switch form-check-inline">
                       <input
                         class="form-check-input"
@@ -1872,7 +1825,7 @@
                   <label class="input-group-text w-50"
                     >Allow requesting "shared folder"</label
                   >
-                  <label class="input-group-text  w-50">
+                  <label class="input-group-text w-50">
                     <div class="form-check form-switch form-check-inline">
                       <input
                         class="form-check-input"
@@ -2483,7 +2436,7 @@
                   <label class="input-group-text w-50"
                     >Enable waterfall data</label
                   >
-                  <label class="input-group-text  w-50">
+                  <label class="input-group-text w-50">
                     <div class="form-check form-switch form-check-inline">
                       <input
                         class="form-check-input"
@@ -2500,7 +2453,7 @@
                   <label class="input-group-text w-50"
                     >Enable scatter diagram data</label
                   >
-                  <label class="input-group-text  w-50">
+                  <label class="input-group-text w-50">
                     <div class="form-check form-switch form-check-inline">
                       <input
                         class="form-check-input"
@@ -2517,7 +2470,7 @@
                   <label class="input-group-text w-50"
                     >Enable 563Hz only mode</label
                   >
-                  <label class="input-group-text  w-50">
+                  <label class="input-group-text w-50">
                     <div class="form-check form-switch form-check-inline">
                       <input
                         class="form-check-input"
@@ -2532,7 +2485,7 @@
                 </div>
                 <div class="input-group input-group-sm mb-1">
                   <label class="input-group-text w-50">Respond to CQ</label>
-                  <label class="input-group-text  w-50">
+                  <label class="input-group-text w-50">
                     <div class="form-check form-switch form-check-inline">
                       <input
                         class="form-check-input"
@@ -2547,7 +2500,7 @@
                 </div>
                 <div class="input-group input-group-sm mb-1">
                   <label class="input-group-text w-50">RX buffer size</label>
-                  <label class="input-group-text  w-50">
+                  <label class="input-group-text w-50">
                     <select
                       class="form-select form-select-sm"
                       id="rx_buffer_size"
@@ -2579,7 +2532,7 @@
                   <label class="input-group-text w-50"
                     >Explorer publishing</label
                   >
-                  <label class="input-group-text  w-50">
+                  <label class="input-group-text w-50">
                     <div class="form-check form-switch form-check-inline">
                       <input
                         class="form-check-input"
@@ -2596,7 +2549,7 @@
                   <label class="input-group-text w-50"
                     >Explorer stats publishing</label
                   >
-                  <label class="input-group-text  w-50">
+                  <label class="input-group-text w-50">
                     <div class="form-check form-switch form-check-inline">
                       <input
                         class="form-check-input"
@@ -2620,7 +2573,7 @@
               >
                 <div class="input-group input-group-sm mb-1">
                   <label class="input-group-text w-50">Enable autotune</label>
-                  <label class="input-group-text  w-50">
+                  <label class="input-group-text w-50">
                     <div class="form-check form-switch form-check-inline ms-2">
                       <input
                         class="form-check-input"
@@ -2635,7 +2588,7 @@
                 </div>
                 <div class="input-group input-group-sm mb-1">
                   <label class="input-group-text w-50">Enable FSK mode</label>
-                  <label class="input-group-text  w-50">
+                  <label class="input-group-text w-50">
                     <div class="form-check form-switch form-check-inline ms-2">
                       <input
                         class="form-check-input"

--- a/gui/src/index.html
+++ b/gui/src/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" data-bs-theme="dark">
+<html lang="en" data-bs-theme="light">
   <head>
     <!-- Required meta tags -->
     <meta charset="utf-8" />
@@ -24,7 +24,7 @@
 
   <body>
     <!-- SECONDARY NAVBAR -->
-    <nav class="navbar fixed-top bg-white border-bottom rounded-3 mt-0 p-2">
+    <nav class="navbar fixed-top border-bottom rounded-3 mt-0 p-2">
       <div style="margin-left: 5px">
         <div
           class="btn-toolbar"
@@ -104,7 +104,7 @@
             >
               <i
                 class="bi bi-diagram-3"
-                style="font-size: 1rem; color: white"
+                style="font-size: 1rem;"
               ></i>
             </button>
           </div>
@@ -273,12 +273,12 @@
       <div class="container p-0" style="margin-top: 55px">
         <div class="row collapse multi-collapse show" id="collapseFirstRow">
           <div class="col">
-            <div class="card text-dark mb-0 border-5 border-start border-end">
-              <div class="card-header p-2 bg-white">
+            <div class="card mb-0 ">
+              <div class="card-header p-2 ">
                 <div class="">
                 <i
                   class="bi bi-volume-up"
-                  style="font-size: 1rem; color: black"
+                  style="font-size: 1rem;"
                 ></i
                 ><strong>AUDIO</strong>
 
@@ -292,10 +292,10 @@
 
               <div class="card-body p-1" style="height:100px">
                 <div class="input-group input-group-sm mb-1">
-                  <span class="input-group-text bg-white">
+                  <span class="input-group-text ">
                     <i
                       class="bi bi-mic-fill"
-                      style="font-size: 1rem; color: black"
+                      style="font-size: 1rem;"
                     ></i>
                   </span>
                   <select
@@ -307,10 +307,10 @@
                   </select>
                 </div>
                 <div class="input-group input-group-sm mb-1">
-                  <span class="input-group-text bg-white">
+                  <span class="input-group-text ">
                     <i
                       class="bi bi-volume-up"
-                      style="font-size: 1rem; color: black"
+                      style="font-size: 1rem;"
                     ></i>
                   </span>
                   <select
@@ -320,18 +320,18 @@
                   ></select>
                 </div>
               </div>
-              <div class="card-footer text-muted small bg-white">
+              <div class="card-footer text-muted small ">
                 Please select audio device for RX and TX
               </div>
             </div>
             <!--Start of TNC rig control pane-->
           </div>
           <div class="col">
-            <div class="card text-dark mb-0  border-5 border-start border-end">
-              <div class="card-header p-1 bg-white">
+            <div class="card mb-0  ">
+              <div class="card-header p-1 ">
                 <i
                   class="bi bi-projector"
-                  style="font-size: 1rem; color: black"
+                  style="font-size: 1rem;"
                 ></i
                 ><strong> TNC RIG CONTROL</strong>
                 <div
@@ -407,10 +407,10 @@
                 <div id="radio-control-rigctld">
                   <div class="input-group input-group-sm mb-1">
                     <div class="input-group input-group-sm mb-1">
-                      <span class="input-group-text bg-white"
+                      <span class="input-group-text "
                         >Rigctld Network settings</span
                       >
-                      <span class="input-group-text bg-white">IP</span>
+                      <span class="input-group-text ">IP</span>
                       <input
                         type="text"
                         class="form-control"
@@ -419,7 +419,7 @@
                         aria-label="Device IP"
                         aria-describedby="basic-addon1"
                       />
-                      <span class="input-group-text bg-white">Port</span>
+                      <span class="input-group-text ">Port</span>
                       <input
                         type="text"
                         class="form-control"
@@ -431,7 +431,7 @@
                     </div>
 
                     <div class="input-group input-group-sm mb-1">
-                    <span class="input-group-text bg-white">Rigctld application</span>
+                    <span class="input-group-text ">Rigctld application</span>
                     <button
                       class="btn btn-outline-success"
                       type="button"
@@ -481,7 +481,7 @@
                   happens automatically.
                 </div>
               </div>
-              <div class="card-footer text-muted small bg-white" id="hamlib_info_field">
+              <div class="card-footer text-muted small " id="hamlib_info_field">
                 Define TNC rig control mode (none/hamlib)
               </div>
             </div>
@@ -492,8 +492,8 @@
           id="collapseSecondRow"
         >
           <div class="col">
-            <div class="card text-dark mb-1  border-5 border-start border-end">
-              <div class="card-header bg-white p-2"><i class="bi bi-house-door"></i><strong> MY STATION</strong></div>
+            <div class="card mb-1  ">
+              <div class="card-header  p-2"><i class="bi bi-house-door"></i><strong> MY STATION</strong></div>
               <div class="card-body p-2">
                 <div class="row">
                   <div class="col-md-auto">
@@ -505,10 +505,10 @@
                       data-bs-html="false"
                       title="Enter your callsign and save it"
                     >
-                      <span class="input-group-text bg-white">
+                      <span class="input-group-text ">
                         <i
                           class="bi bi-person-bounding-box"
-                          style="font-size: 1rem; color: black"
+                          style="font-size: 1rem;"
                         ></i>
                       </span>
                       <input
@@ -555,10 +555,10 @@
                       data-bs-html="false"
                       title="Enter your gridsquare and save it"
                     >
-                      <span class="input-group-text bg-white">
+                      <span class="input-group-text ">
                         <i
                           class="bi bi-house-fill"
-                          style="font-size: 1rem; color: black"
+                          style="font-size: 1rem;"
                         ></i>
                       </span>
                       <input
@@ -579,11 +579,11 @@
             </div>
           </div>
           <div class="col">
-            <div class="card text-dark mb-0  border-5 border-start border-end">
-              <div class="card-header p-2 bg-white d-flex">
+            <div class="card mb-0  ">
+              <div class="card-header p-2  d-flex">
                 <i
                   class="bi bi-cloud-download ms-1 me-1"
-                  style="font-size: 1rem; color: black"
+                  style="font-size: 1rem;"
                 ></i>
                 <strong>UPDATER</strong>
                 <div class="progress w-75 ms-1 m-1">
@@ -641,11 +641,11 @@
       <div class="container mt-2 p-0">
         <div class="row collapse multi-collapse" id="collapseThirdRow">
           <div class="col-5">
-            <div class="card text-dark mb-1  border-5 border-start border-end">
-              <div class="card-header p-1 bg-white">
+            <div class="card mb-1  ">
+              <div class="card-header p-1 ">
                 <i
                   class="bi bi-volume-up"
-                  style="font-size: 1rem; color: black"
+                  style="font-size: 1rem;"
                 ></i>
                 <strong>AUDIO LEVEL</strong>
                 <button
@@ -780,8 +780,8 @@
             </div>
           </div>
           <div class="col">
-            <div class="card text-dark mb-1  border-5 border-start border-end">
-              <div class="card-header p-2 bg-white">
+            <div class="card mb-1  ">
+              <div class="card-header p-2 ">
                 <strong>PING, CQ & BEACON</strong>
               </div>
               <div class="card-body p-2">
@@ -890,8 +890,8 @@
         </div>
         <div class="row collapse multi-collapse" id="collapseFourthRow">
           <div class="col-5">
-            <div class="card text-dark mb-1  border-5 border-start border-end">
-              <div class="card-header p-1 bg-white">
+            <div class="card mb-1  ">
+              <div class="card-header p-1 ">
                 <div
                   class="btn-group btn-group-sm"
                   role="group"
@@ -987,13 +987,12 @@
             </div>
           </div>
           <div class="col">
-            <div class="card text-dark mb-1  border-5 border-start border-end" style="height: 240px">
+            <div class="card mb-1  " style="height: 240px">
               <!--325px-->
-              <div class="card-header p-2 bg-white">
+              <div class="card-header p-2 ">
                 <i
                   class="bi bi-list-columns-reverse"
-                  style="font-size: 1rem; color: black"
-                  style="font-size: 1rem; color: black"
+                  style="font-size: 1rem;"
                 ></i>
                 <strong> HEARD STATIONS</strong>
               </div>
@@ -1048,7 +1047,7 @@
         >
           <i
             class="bi bi-folder2-open"
-            style="font-size: 1rem; color: white"
+            style="font-size: 1rem;"
           ></i>
         </button>
         <h5 id="receivedFilesSidebarLabel">Filetransfer</h5>
@@ -1130,7 +1129,7 @@
           <div class="container mt-1">
             <div class="row mb-1">
               <div class="col">
-                <div class="card text-dark mb-0">
+                <div class="card mb-0">
                   <div class="card-header p-1"><strong>DX Station</strong></div>
                   <div class="card-body p-2">
                     <div class="row">
@@ -1175,7 +1174,7 @@
             <!--row-->
             <div class="row mb-1">
               <div class="col">
-                <div class="card text-dark mb-0">
+                <div class="card mb-0">
                   <!--
                               <div class="card-header p-1"> <strong>Data</strong>
                               </div>
@@ -1193,7 +1192,7 @@
             <!--row-->
             <div class="row mb-1">
               <div class="col">
-                <div class="card text-dark mb-0">
+                <div class="card mb-0">
                   <div class="card-header p-1"><strong>Mode</strong></div>
                   <div class="card-body p-2">
                     <div class="row">
@@ -1249,18 +1248,6 @@
                 </button>
               </div>
             </div>
-            <!--
-                     <div class="row">
-                         <div class="col">
-                             <div class="card text-dark bg-light mb-0" >
-                                 <div class="card-header p-2">Info </div>
-                                 <div class="card-body p-2">
-                                     123
-                                 </div>
-                             </div>
-                         </div>
-                     </div>
-                     -->
             <div class="row">
               <div class="col"></div>
             </div>
@@ -1274,7 +1261,7 @@
     <!--end of blur div -->
     <!---------------------------------------------------------------------- FOOTER AREA ------------------------------------------------------------>
     <div class="container-fluid">
-      <nav class="navbar fixed-bottom navbar-expand-xl navbar-light bg-white border-top rounded-3 p-2">
+      <nav class="navbar fixed-bottom navbar-expand-xl navbar-light  border-top rounded-3 p-2">
         <div class="col-sm-2">
           <div class="btn-toolbar" role="toolbar" style="margin-left: 2px">
             <div class="btn-group btn-group-sm me-1" role="group">
@@ -1290,7 +1277,7 @@
               >
                 <i
                   class="bi bi-broadcast-pin"
-                  style="font-size: 0.8rem; color: white"
+                  style="font-size: 0.8rem;"
                 ></i>
               </button>
             </div>
@@ -1307,7 +1294,7 @@
               >
                 <i
                   class="bi bi-cpu"
-                  style="font-size: 0.8rem; color: white"
+                  style="font-size: 0.8rem;"
                 ></i>
               </button>
             </div>
@@ -1324,7 +1311,7 @@
               >
                 <i
                   class="bi bi-arrow-left-right"
-                  style="font-size: 0.8rem; color: white"
+                  style="font-size: 0.8rem;"
                 ></i>
               </button>
             </div>
@@ -1341,7 +1328,7 @@
               >
                 <i
                   class="bi bi-file-earmark-binary"
-                  style="font-size: 0.8rem; color: white"
+                  style="font-size: 0.8rem;"
                 ></i>
               </button>
             </div>
@@ -1358,7 +1345,7 @@
               >
                 <i
                   class="bi bi-usb-symbol"
-                  style="font-size: 0.8rem; color: white"
+                  style="font-size: 0.8rem;"
                 ></i>
               </button>
             </div>
@@ -1402,7 +1389,7 @@
                   >
                     <i
                       class="bi bi-check-lg"
-                      style="font-size: 0.8rem; color: white"
+                      style="font-size: 0.8rem;"
                     ></i>
                   </button>
                 </div>
@@ -1508,7 +1495,7 @@
             <span class="input-group-text">
               <i
                 class="bi bi-speedometer2"
-                style="font-size: 1rem; color: black"
+                style="font-size: 1rem;"
               ></i>
             </span>
             <span
@@ -1522,13 +1509,13 @@
               <i
                 id="speed_level"
                 class="bi bi-reception-0"
-                style="font-size: 1rem; color: black"
+                style="font-size: 1rem;"
               ></i>
             </span>
             <span class="input-group-text">
               <i
                 class="bi bi-file-earmark-binary"
-                style="font-size: 1rem; color: black"
+                style="font-size: 1rem;"
               ></i>
             </span>
             <span
@@ -1805,7 +1792,7 @@
                 </div>
                 <div class="input-group input-group-sm mb-1">
                   <label class="input-group-text w-50">Enable fancy GUI</label>
-                  <label class="input-group-text bg-white w-50">
+                  <label class="input-group-text  w-50">
                     <div class="form-check form-switch form-check-inline">
                       <input
                         class="form-check-input"
@@ -1852,7 +1839,7 @@
                   <label class="input-group-text w-50"
                     >Enable "is typing"</label
                   >
-                  <label class="input-group-text bg-white w-50">
+                  <label class="input-group-text  w-50">
                     <div class="form-check form-switch form-check-inline">
                       <input
                         class="form-check-input"
@@ -1870,7 +1857,7 @@
                   <label class="input-group-text w-50"
                     >Allow requesting "user profile"</label
                   >
-                  <label class="input-group-text bg-white w-50">
+                  <label class="input-group-text  w-50">
                     <div class="form-check form-switch form-check-inline">
                       <input
                         class="form-check-input"
@@ -1885,7 +1872,7 @@
                   <label class="input-group-text w-50"
                     >Allow requesting "shared folder"</label
                   >
-                  <label class="input-group-text bg-white w-50">
+                  <label class="input-group-text  w-50">
                     <div class="form-check form-switch form-check-inline">
                       <input
                         class="form-check-input"
@@ -2496,7 +2483,7 @@
                   <label class="input-group-text w-50"
                     >Enable waterfall data</label
                   >
-                  <label class="input-group-text bg-white w-50">
+                  <label class="input-group-text  w-50">
                     <div class="form-check form-switch form-check-inline">
                       <input
                         class="form-check-input"
@@ -2513,7 +2500,7 @@
                   <label class="input-group-text w-50"
                     >Enable scatter diagram data</label
                   >
-                  <label class="input-group-text bg-white w-50">
+                  <label class="input-group-text  w-50">
                     <div class="form-check form-switch form-check-inline">
                       <input
                         class="form-check-input"
@@ -2530,7 +2517,7 @@
                   <label class="input-group-text w-50"
                     >Enable 563Hz only mode</label
                   >
-                  <label class="input-group-text bg-white w-50">
+                  <label class="input-group-text  w-50">
                     <div class="form-check form-switch form-check-inline">
                       <input
                         class="form-check-input"
@@ -2545,7 +2532,7 @@
                 </div>
                 <div class="input-group input-group-sm mb-1">
                   <label class="input-group-text w-50">Respond to CQ</label>
-                  <label class="input-group-text bg-white w-50">
+                  <label class="input-group-text  w-50">
                     <div class="form-check form-switch form-check-inline">
                       <input
                         class="form-check-input"
@@ -2560,7 +2547,7 @@
                 </div>
                 <div class="input-group input-group-sm mb-1">
                   <label class="input-group-text w-50">RX buffer size</label>
-                  <label class="input-group-text bg-white w-50">
+                  <label class="input-group-text  w-50">
                     <select
                       class="form-select form-select-sm"
                       id="rx_buffer_size"
@@ -2592,7 +2579,7 @@
                   <label class="input-group-text w-50"
                     >Explorer publishing</label
                   >
-                  <label class="input-group-text bg-white w-50">
+                  <label class="input-group-text  w-50">
                     <div class="form-check form-switch form-check-inline">
                       <input
                         class="form-check-input"
@@ -2609,7 +2596,7 @@
                   <label class="input-group-text w-50"
                     >Explorer stats publishing</label
                   >
-                  <label class="input-group-text bg-white w-50">
+                  <label class="input-group-text  w-50">
                     <div class="form-check form-switch form-check-inline">
                       <input
                         class="form-check-input"
@@ -2633,7 +2620,7 @@
               >
                 <div class="input-group input-group-sm mb-1">
                   <label class="input-group-text w-50">Enable autotune</label>
-                  <label class="input-group-text bg-white w-50">
+                  <label class="input-group-text  w-50">
                     <div class="form-check form-switch form-check-inline ms-2">
                       <input
                         class="form-check-input"
@@ -2648,7 +2635,7 @@
                 </div>
                 <div class="input-group input-group-sm mb-1">
                   <label class="input-group-text w-50">Enable FSK mode</label>
-                  <label class="input-group-text bg-white w-50">
+                  <label class="input-group-text  w-50">
                     <div class="form-check form-switch form-check-inline ms-2">
                       <input
                         class="form-check-input"

--- a/gui/src/index.html
+++ b/gui/src/index.html
@@ -24,7 +24,7 @@
 
   <body>
     <!-- SECONDARY NAVBAR -->
-    <nav class="navbar fixed-top bg-light shadow-sm mt-0 mb-1 pb-1 pt-1">
+    <nav class="navbar fixed-top bg-white border-bottom rounded-3 mt-0 p-2">
       <div style="margin-left: 5px">
         <div
           class="btn-toolbar"
@@ -120,8 +120,8 @@
           data-bs-html="false"
           title="Abort session and stop transmissions"
         >
-          <i class="bi bi-x-octagon-fill"></i> &nbsp;STOP &nbsp;<i
-            class="bi bi-x-octagon-fill"
+          <i class="bi bi-sign-stop-fill"></i> &nbsp;STOP TRANSMISSION&nbsp;<i
+            class="bi bi-sign-stop-fill"
           ></i>
         </button>
       </div>
@@ -273,17 +273,26 @@
       <div class="container p-0" style="margin-top: 55px">
         <div class="row collapse multi-collapse show" id="collapseFirstRow">
           <div class="col">
-            <div class="card text-dark mb-0">
-              <div class="card-header p-1">
+            <div class="card text-dark mb-0 border-5 border-start border-end">
+              <div class="card-header p-2 bg-white">
+                <div class="">
                 <i
                   class="bi bi-volume-up"
                   style="font-size: 1rem; color: black"
                 ></i
                 ><strong>AUDIO</strong>
+
+                  </div>
               </div>
-              <div class="card-body p-2 mb-1">
+
+
+
+
+
+
+              <div class="card-body p-1" style="height:100px">
                 <div class="input-group input-group-sm mb-1">
-                  <span class="input-group-text">
+                  <span class="input-group-text bg-white">
                     <i
                       class="bi bi-mic-fill"
                       style="font-size: 1rem; color: black"
@@ -298,7 +307,7 @@
                   </select>
                 </div>
                 <div class="input-group input-group-sm mb-1">
-                  <span class="input-group-text">
+                  <span class="input-group-text bg-white">
                     <i
                       class="bi bi-volume-up"
                       style="font-size: 1rem; color: black"
@@ -311,15 +320,15 @@
                   ></select>
                 </div>
               </div>
-              <div class="card-footer text-muted small">
+              <div class="card-footer text-muted small bg-white">
                 Please select audio device for RX and TX
               </div>
             </div>
             <!--Start of TNC rig control pane-->
           </div>
           <div class="col">
-            <div class="card text-dark mb-0">
-              <div class="card-header p-1">
+            <div class="card text-dark mb-0  border-5 border-start border-end">
+              <div class="card-header p-1 bg-white">
                 <i
                   class="bi bi-projector"
                   style="font-size: 1rem; color: black"
@@ -384,7 +393,7 @@
                   </label>
                 </div>
               </div>
-              <div class="card-body p-2">
+              <div class="card-body p-2" style="height:100px">
                 <!-- RADIO CONTROL DISABLED -->
                 <div id="radio-control-disabled">
                   <p class="small">
@@ -398,10 +407,10 @@
                 <div id="radio-control-rigctld">
                   <div class="input-group input-group-sm mb-1">
                     <div class="input-group input-group-sm mb-1">
-                      <span class="input-group-text"
+                      <span class="input-group-text bg-white"
                         >Rigctld Network settings</span
                       >
-                      <span class="input-group-text">IP</span>
+                      <span class="input-group-text bg-white">IP</span>
                       <input
                         type="text"
                         class="form-control"
@@ -410,7 +419,7 @@
                         aria-label="Device IP"
                         aria-describedby="basic-addon1"
                       />
-                      <span class="input-group-text">Port</span>
+                      <span class="input-group-text bg-white">Port</span>
                       <input
                         type="text"
                         class="form-control"
@@ -421,7 +430,8 @@
                       />
                     </div>
 
-                    <span class="input-group-text">Rigctld application</span>
+                    <div class="input-group input-group-sm mb-1">
+                    <span class="input-group-text bg-white">Rigctld application</span>
                     <button
                       class="btn btn-outline-success"
                       type="button"
@@ -447,7 +457,7 @@
                     <button
                       type="button"
                       id="testHamlib"
-                      class="btn btn-sm btn-outline-secondary"
+                      class="btn btn-sm btn-outline-secondary ms-1"
                       data-bs-placement="bottom"
                       data-bs-toggle="tooltip"
                       data-bs-trigger="hover"
@@ -458,6 +468,7 @@
                     </button>
                   </div>
                 </div>
+                  </div>
 
                 <!-- RADIO CONTROL HELP -->
                 <div id="radio-control-help">
@@ -470,7 +481,7 @@
                   happens automatically.
                 </div>
               </div>
-              <div class="card-footer text-muted small" id="hamlib_info_field">
+              <div class="card-footer text-muted small bg-white" id="hamlib_info_field">
                 Define TNC rig control mode (none/hamlib)
               </div>
             </div>
@@ -481,8 +492,8 @@
           id="collapseSecondRow"
         >
           <div class="col">
-            <div class="card text-dark mb-1">
-              <div class="card-header p-1"><strong>MY STATION</strong></div>
+            <div class="card text-dark mb-1  border-5 border-start border-end">
+              <div class="card-header bg-white p-2"><i class="bi bi-house-door"></i><strong> MY STATION</strong></div>
               <div class="card-body p-2">
                 <div class="row">
                   <div class="col-md-auto">
@@ -494,7 +505,7 @@
                       data-bs-html="false"
                       title="Enter your callsign and save it"
                     >
-                      <span class="input-group-text">
+                      <span class="input-group-text bg-white">
                         <i
                           class="bi bi-person-bounding-box"
                           style="font-size: 1rem; color: black"
@@ -544,7 +555,7 @@
                       data-bs-html="false"
                       title="Enter your gridsquare and save it"
                     >
-                      <span class="input-group-text">
+                      <span class="input-group-text bg-white">
                         <i
                           class="bi bi-house-fill"
                           style="font-size: 1rem; color: black"
@@ -568,8 +579,8 @@
             </div>
           </div>
           <div class="col">
-            <div class="card text-dark mb-0">
-              <div class="card-header p-1 d-flex">
+            <div class="card text-dark mb-0  border-5 border-start border-end">
+              <div class="card-header p-2 bg-white d-flex">
                 <i
                   class="bi bi-cloud-download ms-1 me-1"
                   style="font-size: 1rem; color: black"
@@ -630,8 +641,8 @@
       <div class="container mt-2 p-0">
         <div class="row collapse multi-collapse" id="collapseThirdRow">
           <div class="col-5">
-            <div class="card text-dark mb-1">
-              <div class="card-header p-1">
+            <div class="card text-dark mb-1  border-5 border-start border-end">
+              <div class="card-header p-1 bg-white">
                 <i
                   class="bi bi-volume-up"
                   style="font-size: 1rem; color: black"
@@ -769,8 +780,8 @@
             </div>
           </div>
           <div class="col">
-            <div class="card text-dark mb-1">
-              <div class="card-header p-1">
+            <div class="card text-dark mb-1  border-5 border-start border-end">
+              <div class="card-header p-2 bg-white">
                 <strong>PING, CQ & BEACON</strong>
               </div>
               <div class="card-body p-2">
@@ -879,8 +890,8 @@
         </div>
         <div class="row collapse multi-collapse" id="collapseFourthRow">
           <div class="col-5">
-            <div class="card text-dark mb-1">
-              <div class="card-header p-1">
+            <div class="card text-dark mb-1  border-5 border-start border-end">
+              <div class="card-header p-1 bg-white">
                 <div
                   class="btn-group btn-group-sm"
                   role="group"
@@ -976,9 +987,9 @@
             </div>
           </div>
           <div class="col">
-            <div class="card text-dark mb-1" style="height: 240px">
+            <div class="card text-dark mb-1  border-5 border-start border-end" style="height: 240px">
               <!--325px-->
-              <div class="card-header p-1">
+              <div class="card-header p-2 bg-white">
                 <i
                   class="bi bi-list-columns-reverse"
                   style="font-size: 1rem; color: black"
@@ -1263,7 +1274,7 @@
     <!--end of blur div -->
     <!---------------------------------------------------------------------- FOOTER AREA ------------------------------------------------------------>
     <div class="container-fluid">
-      <nav class="navbar fixed-bottom navbar-expand-xl navbar-light bg-light">
+      <nav class="navbar fixed-bottom navbar-expand-xl navbar-light bg-white border-top rounded-3 p-2">
         <div class="col-sm-2">
           <div class="btn-toolbar" role="toolbar" style="margin-left: 2px">
             <div class="btn-group btn-group-sm me-1" role="group">

--- a/gui/src/index.html
+++ b/gui/src/index.html
@@ -1700,7 +1700,9 @@
                     class="form-select form-select-sm w-50"
                     id="theme_selector"
                   >
-                    <option value="default">Default</option>
+                    <option value="default_light">Default (light)</option>
+                    <option value="default_dark">Default (dark)</option>
+                    <option value="default_auto">Default (auto)</option>
                     <option value="cerulean">Cerulean</option>
                     <option value="cosmo">Cosmo</option>
                     <option value="cyborg">Cyborg</option>

--- a/gui/src/styles.css
+++ b/gui/src/styles.css
@@ -105,5 +105,5 @@ https://stackoverflow.com/a/9622873
 }
 /* default dark theme mods */
 [data-bs-theme="dark"] {
-/* default dark theme mods */
+  /* default dark theme mods */
 }

--- a/gui/src/styles.css
+++ b/gui/src/styles.css
@@ -1,4 +1,3 @@
-
 /* disable scrolling in main window */
 body {
   padding-right: 0px !important;
@@ -95,18 +94,15 @@ https://stackoverflow.com/a/9622873
   transition: 0.5s;
 }
 
-
-
 /* theme area */
 
 /* default light theme mods */
 [data-bs-theme="light"] {
-    .card-header{
-       background-color: var(--bs-card-cap-bg);
-       /*--bs-card-cap-bg: rgba(var(--bs-body-color-rgb), 0.3);*/
-    }
+  .card-header {
+    background-color: var(--bs-card-cap-bg);
+    /*--bs-card-cap-bg: rgba(var(--bs-body-color-rgb), 0.3);*/
+  }
 }
 /* default light theme mods */
 [data-bs-theme="dark"] {
-
 }

--- a/gui/src/styles.css
+++ b/gui/src/styles.css
@@ -1,3 +1,4 @@
+
 /* disable scrolling in main window */
 body {
   padding-right: 0px !important;
@@ -92,4 +93,20 @@ https://stackoverflow.com/a/9622873
 .image-overlay:hover {
   opacity: 0.75 !important;
   transition: 0.5s;
+}
+
+
+
+/* theme area */
+
+/* default light theme mods */
+[data-bs-theme="light"] {
+    .card-header{
+       background-color: var(--bs-card-cap-bg);
+       /*--bs-card-cap-bg: rgba(var(--bs-body-color-rgb), 0.3);*/
+    }
+}
+/* default light theme mods */
+[data-bs-theme="dark"] {
+
 }

--- a/gui/src/styles.css
+++ b/gui/src/styles.css
@@ -103,6 +103,7 @@ https://stackoverflow.com/a/9622873
     /*--bs-card-cap-bg: rgba(var(--bs-body-color-rgb), 0.3);*/
   }
 }
-/* default light theme mods */
+/* default dark theme mods */
 [data-bs-theme="dark"] {
+/* default dark theme mods */
 }

--- a/tnc/config.ini
+++ b/tnc/config.ini
@@ -4,15 +4,15 @@ tncport = 3000
 
 [STATION]
 #station settings
-mycall = DN2LS-0
-mygrid = JN48cs
+mycall = DJ2LS-9
+mygrid = JN12AA
 ssid_list = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 
 [AUDIO]
 #audio settings
-rx = 6
-tx = 6
-txaudiolevel = 20
+rx = 2
+tx = 3
+txaudiolevel = 78
 auto_tune = False
 
 [RADIO]
@@ -26,8 +26,8 @@ rigctld_port = 4532
 scatter = True
 fft = True
 narrowband = False
-fmin = -150.0
-fmax = 150.0
+fmin = -250.0
+fmax = 250.0
 qrv = True
 rxbuffersize = 16
 explorer = False


### PR DESCRIPTION
The next version of bootstrap ( v 5.3 ) brings us dark mode features and easier designing of custom themes.
This PR tries to add compatibility with v5.3 and making the GUI ready for these versions. 

Todos for this PR:

- [x] Make GUI as much flexible as possible so we can use all bootstrap features natively without customizing and modification. This means, we have to remove all "custom colors" which have been set by css style rules and all used bootstrap color overriding which are not part of the default templates, like the headers of "bootstrap cards".
- [x] Add a design changer for "light/dark/auto"
- [x] Fix smaller GUI related parts which are html/css only

Not Todos for this PR

- no bug fixing of gui related bugs in JS/NodeJS code


<img width="1243" alt="image" src="https://user-images.githubusercontent.com/75909252/225537074-a276ceb3-ca2a-425c-81f0-879dcfee0860.png">
