### PR TITLE
Only one main screen

### DIFF
--- a/gui/src/components/infoScreen.vue
+++ b/gui/src/components/infoScreen.vue
@@ -90,9 +90,7 @@ onMounted(shuffleCards);
 </script>
 
 <template>
-<infoScreen_updater/>
-
-
+  <infoScreen_updater />
   <div class="container-fluid">
     <div class="row mt-2">
       <hr />

--- a/gui/src/components/main.vue
+++ b/gui/src/components/main.vue
@@ -159,18 +159,7 @@ function stopAllTransmissions() {
                   id="collapseFirstRow"
                 >
                   <div class="col">
-                  </div>
-                  <div class="col">
                     <main_rig_control />
-                  </div>
-                </div>
-                <div
-                  class="row collapse multi-collapse show mt-4"
-                  id="collapseSecondRow"
-                >
-                  <div class="col">
-                  </div>
-                  <div class="col">
                   </div>
                 </div>
               </div>

--- a/gui/src/components/main.vue
+++ b/gui/src/components/main.vue
@@ -153,19 +153,10 @@ function stopAllTransmissions() {
               <!-------------------------------- MAIN AREA ---------------->
 
               <!------------------------------------------------------------------------------------------>
-              <div class="container p-3">
-                <div
-                  class="row collapse multi-collapse show mt-4"
-                  id="collapseFirstRow"
-                >
-                  <div class="col">
-                    <main_rig_control />
-                  </div>
-                </div>
-              </div>
               <div class="container">
-                <div class="row collapse multi-collapse" id="collapseThirdRow">
+                <div class="row">
                   <main_active_rig_control />
+                  <main_rig_control />
 
                   <div class="col-5">
                     <main_active_audio_level />
@@ -173,11 +164,6 @@ function stopAllTransmissions() {
                   <div class="col">
                     <main_active_broadcasts />
                   </div>
-                </div>
-                <div
-                  class="row collapse multi-collapse mt-3"
-                  id="collapseFourthRow"
-                >
                   <div class="col-5">
                     <main_active_stats />
                   </div>

--- a/gui/src/components/main_rig_control.vue
+++ b/gui/src/components/main_rig_control.vue
@@ -61,8 +61,9 @@ alert("not yet implemented")
 </script>
 
 <template>
-  <div class="card mb-0">
-    <div class="card-header p-1">
+  <div class="mb-3">
+    <div class="card mb-1">
+      <div class="card-header p-1">
       <div class="container">
         <div class="row">
           <div class="col-1">
@@ -258,5 +259,6 @@ alert("not yet implemented")
                 Define Modem rig control mode (none/hamlib)
               </div>
               -->
+  </div>
   </div>
 </template>

--- a/gui/src/components/settings.vue
+++ b/gui/src/components/settings.vue
@@ -2,6 +2,7 @@
 import settings_station from "./settings_station.vue";
 import settings_gui from "./settings_gui.vue";
 import settings_chat from "./settings_chat.vue";
+import settings_rigcontrol from "./settings_rigcontrol.vue";
 import settings_hamlib from "./settings_hamlib.vue";
 import settings_modem from "./settings_modem.vue";
 import settings_web from "./settings_web.vue";
@@ -66,6 +67,20 @@ import settings_exp from "./settings_exp.vue";
                 aria-selected="true"
               >
                 Chat
+              </button>
+            </li>
+            <li class="nav-item" role="presentation">
+              <button
+                class="nav-link"
+                id="rigcontrol-tab"
+                data-bs-toggle="tab"
+                data-bs-target="#rigcontrol"
+                type="button"
+                role="tab"
+                aria-controls="profile"
+                aria-selected="false"
+              >
+                Rig Control
               </button>
             </li>
             <li class="nav-item" role="presentation">
@@ -160,6 +175,16 @@ import settings_exp from "./settings_exp.vue";
               tabindex="0"
             >
               <settings_chat />
+            </div>
+
+            <div
+              class="tab-pane"
+              id="rigcontrol"
+              role="tabpanel"
+              aria-labelledby="rigcontrol-tab"
+              tabindex="0"
+            >
+              <settings_rigcontrol />
             </div>
 
             <div

--- a/gui/src/components/settings_rigcontrol.vue
+++ b/gui/src/components/settings_rigcontrol.vue
@@ -1,0 +1,57 @@
+<script setup lang="ts">
+import { saveSettingsToFile } from "../js/settingsHandler";
+
+import { setActivePinia } from "pinia";
+import pinia from "../store/index";
+setActivePinia(pinia);
+
+import { useSettingsStore } from "../store/settingsStore.js";
+const settings = useSettingsStore(pinia);
+function saveSettings() {
+  saveSettingsToFile();
+}
+</script>
+
+<template>
+  <div class="input-group input-group-sm mb-1">
+    <span class="input-group-text" style="width: 180px">Rig Control</span>
+
+    <select
+      class="form-select form-select-sm"
+      aria-label=".form-select-sm"
+      id="rigcontrol_radiocontrol"
+      @change="saveSettings"
+      v-model="settings.radiocontrol"
+    >
+      <option selected value="disabled">Disabled / VOX (no rig control - use with VOX)</option>
+      <option selected value="rigctld">Rigctld (Hamlib)</option>
+      <option selected value="tci">TCI</option>
+    </select>
+  </div>
+
+  <hr class="m-2" />
+
+  <div class="input-group input-group-sm mb-1">
+    <span class="input-group-text" style="width: 180px">TCI IP Address</span>
+    <input
+      type="text"
+      class="form-control"
+      placeholder="TCI IP"
+      id="rigcontrol_tci_ip"
+      aria-label="Device IP"
+      v-model="settings.tci_ip"
+    />
+  </div>
+
+  <div class="input-group input-group-sm mb-1">
+    <span class="input-group-text" style="width: 180px">TCI port</span>
+    <input
+      type="text"
+      class="form-control"
+      placeholder="TCI port"
+      id="rigcontrol_tci_port"
+      aria-label="Device Port"
+      v-model="settings.tci_port"
+    />
+  </div>
+</template>

--- a/gui/src/store/stateStore.js
+++ b/gui/src/store/stateStore.js
@@ -84,55 +84,11 @@ export const useStateStore = defineStore("stateStore", () => {
     modem_connection.value = state;
 
     if (modem_connection.value == "open") {
-      // collapse settings screen
-      var collapseFirstRow = new bootstrap.Collapse(
-        document.getElementById("collapseFirstRow"),
-        { toggle: false },
-      );
-      collapseFirstRow.hide();
-      var collapseSecondRow = new bootstrap.Collapse(
-        document.getElementById("collapseSecondRow"),
-        { toggle: false },
-      );
-      collapseSecondRow.hide();
-      var collapseThirdRow = new bootstrap.Collapse(
-        document.getElementById("collapseThirdRow"),
-        { toggle: false },
-      );
-      collapseThirdRow.show();
-      var collapseFourthRow = new bootstrap.Collapse(
-        document.getElementById("collapseFourthRow"),
-        { toggle: false },
-      );
-      collapseFourthRow.show();
-
       //Set tuning for fancy graphics mode (high/low CPU)
       //set_CPU_mode();
 
       //GUI will auto connect to TNC if already running, if that is the case increment start count if 0
       if (modemStartCount.value == 0) modemStartCount.value++;
-    } else {
-      // collapse settings screen
-      var collapseFirstRow = new bootstrap.Collapse(
-        document.getElementById("collapseFirstRow"),
-        { toggle: false },
-      );
-      collapseFirstRow.show();
-      var collapseSecondRow = new bootstrap.Collapse(
-        document.getElementById("collapseSecondRow"),
-        { toggle: false },
-      );
-      collapseSecondRow.show();
-      var collapseThirdRow = new bootstrap.Collapse(
-        document.getElementById("collapseThirdRow"),
-        { toggle: false },
-      );
-      collapseThirdRow.hide();
-      var collapseFourthRow = new bootstrap.Collapse(
-        document.getElementById("collapseFourthRow"),
-        { toggle: false },
-      );
-      collapseFourthRow.hide();
     }
   }
 


### PR DESCRIPTION
- Add the rig control options to the settings area in a dedicated tab
- Move the default rig control card to the active main screen
- Delete the default inactive screen mode
- Set the active screen as the only main screen mode
