### PR TITLE
fix loading default config

### DIFF
--- a/gui/src/store/settingsStore.js
+++ b/gui/src/store/settingsStore.js
@@ -101,7 +101,7 @@ const defaultConfig = {
   },
 };
 
-nconf.defaults(defaultConfig.local);
+nconf.defaults(defaultConfig);
 nconf.required(["local:host", "local:port"]);
 
 export const settingsStore = reactive(defaultConfig);


### PR DESCRIPTION
without this change, if the user doesn't have a valid config on disk, they just get a white screen on startup due to `nconf.required` throwing an exception.