### PR TITLE
Internal rigctld tweaks for windows users

### DIFF
--- a/modem/config.ini.example
+++ b/modem/config.ini.example
@@ -21,7 +21,7 @@ ip = 127.0.0.1
 port = 4532
 path = 
 command = 
-arguments = --cenas
+arguments = 
 
 [RADIO]
 control = disabled

--- a/modem/helpers.py
+++ b/modem/helpers.py
@@ -18,6 +18,7 @@ from pathlib import Path
 import platform
 import subprocess
 import psutil
+import glob
 
 
 log = structlog.get_logger("helpers")
@@ -738,8 +739,9 @@ def find_binary_path(binary_name="rigctld", search_system_wide=False):
         if platform.system() != 'Windows':
             system_paths.extend(['/usr/bin', '/usr/local/bin', '/bin'])
         else:
-            system_paths.extend(['C:\\Windows\\System32', 'C:\\Windows'])
-
+           system_paths.extend(glob.glob("C:\\Program Files\\Hamlib*\\bin"))
+           system_paths.extend(glob.glob("C:\\Program Files (x86)\\Hamlib*\\bin"))
+            
         for path in system_paths:
             potential_path = os.path.join(path, binary_name)
             if os.path.isfile(potential_path):

--- a/modem/rigctld.py
+++ b/modem/rigctld.py
@@ -221,6 +221,7 @@ class radio:
 
     def format_rigctld_args(self):
         config = self.config['RADIO']  # Accessing the 'RADIO' section of the INI file
+        config_rigctld = self.config['RIGCTLD'] # Accessing the 'RIGCTLD' section of the INI file for custom args
         args = []
 
         # Helper function to check if the value should be ignored
@@ -251,5 +252,10 @@ class radio:
         if not should_ignore(config.get('stop_bits', "0")):
             args += ['--set-conf', f'stop_bits={config["stop_bits"]}']
 
+        # Handle custom arguments for rigctld
+        # Custom args are split via ' ' so python doesn't add extranaeous quotes on windows
+        args += config_rigctld["arguments"].split(" ")
+        #print("Hamlib args ==>" + str(args))
+        
         return args
 


### PR DESCRIPTION
- Process custom arguments for rigctld for all platforms
- Search c:\program files*\Hamlib*\bin for rigctld binaries on Windows
- Remove default custom args from example config