### PR TITLE
support different server ports

### DIFF
--- a/gui/src/components/main_startup_check.vue
+++ b/gui/src/components/main_startup_check.vue
@@ -126,6 +126,7 @@ function testHamlib() {
                       max="65534"
                       min="1025"
                       v-model="settings.local.port"
+                      @change="onChange"
                     />
                   </div>
 
@@ -137,6 +138,7 @@ function testHamlib() {
                       placeholder="modem host (default 127.0.0.1)"
                       id="modem_port"
                       v-model="settings.local.host"
+                      @change="onChange"
                     />
                   </div>
                 </div>

--- a/modem/config.ini.example
+++ b/modem/config.ini.example
@@ -1,4 +1,5 @@
 [NETWORK]
+modemaddress = 127.0.0.1
 modemport = 5000
 
 [STATION]

--- a/modem/config.py
+++ b/modem/config.py
@@ -10,6 +10,7 @@ class CONFIG:
 
     config_types = {
         'NETWORK': {
+            'modemaddress': str,
             'modemport': int,
         },
         'STATION': {

--- a/modem/server.py
+++ b/modem/server.py
@@ -344,4 +344,13 @@ if __name__ == "__main__":
     # initialize database default values
     DatabaseManager(app.event_manager).initialize_default_values()
     wsm.startThreads(app)
-    app.run()
+
+    conf = app.config_manager.read()
+    modemaddress = conf['NETWORK']['modemaddress']
+    modemport = conf['NETWORK']['modemport']
+
+    if not modemaddress:
+        modemaddress = '127.0.0.1'
+    if not modemport:
+        modemport = 5000
+    app.run(modemaddress, modemport)


### PR DESCRIPTION
server supports different ports now - gui needs to be adjusted in a separate step with additional notification. Also pushing the new port to server not working yet. 
--> We need to ensure we are sending the new config first, then changing gui port. but its a special use case. Normally not done by regular users. So we might not use it on healthcheck maybe?