### PR TITLE
Fixing the paths in copy-files.bat to match actual paths

### DIFF
--- a/tools/Windows/copy-files.bat
+++ b/tools/Windows/copy-files.bat
@@ -2,9 +2,9 @@
 REM This will copy the helper batch files to the approriate places for you
 
 echo Copying GUI scripts to GUI directory
-copy GUI* ..\..\gui\
+copy GUI* ..\..\freedata_gui\
 
 echo Copying Modem scripts to Modem directory
-copy MODEM* ..\..\modem\
+copy MODEM* ..\..\freedata_server\
 
 pause


### PR DESCRIPTION
The paths in `tools/Windows/copy-files.bat` hadn't been updated to match the structure of the `develop` branch.  This was keeping me from building on Windows.