### PR TITLE
Fix rigctl health status on gui start always being false

### DIFF
--- a/freedata_gui/src/js/eventHandler.js
+++ b/freedata_gui/src/js/eventHandler.js
@@ -69,7 +69,9 @@ export function stateDispatcher(data) {
     stateStore.dbfs_level_percent = Math.round(
       Math.pow(10, data["audio_dbfs"] / 20) * 100,
     );
-
+    //Accept radio status from here as well, saves us from having to wait for an update from the radio manager
+    //Fixes the health rigctl being offline on startup
+    stateStore.radio_status = data["radio_status"];
     stateStore.channel_busy_slot = data["channel_busy_slot"];
     stateStore.beacon_state = data["is_beacon_running"];
     stateStore.away_from_key = data["is_away_from_key"];


### PR DESCRIPTION
GUI's rig control health will always be unhealthly unless radio manager sends a change.  State info also passes radio status, so use that as a source for radio status as well.  Fixes the icon being yellow/red on startup.