### PR TITLE
Added Czech translation

### DIFF
--- a/freedata_gui/src/locales/cz_Čeština.json
+++ b/freedata_gui/src/locales/cz_Čeština.json
@@ -1,0 +1,15 @@
+{
+    "settings": {
+        "enable": "Aktivovat",
+        "default": "Výchozí",
+        "gui": {
+            "introduction": " související nastavení, jako je přizpůsobení vodopádového motivu, jazyka nebo chování prohlížeče.",
+            "browserautolaunch": "Automaticky spustit prohlížeč",
+            "browserautolaunch_help": "Automaticy otevře prohlížeč s GUI odkazem při startu serveru",
+            "selectlanguage": "Zvolte jazyk",
+            "selectlanguage_help": "Nastaví preferovaný jazyk pro GUI",
+            "waterfalltheme": "Těma vodopádu",
+            "waterfalltheme_help": "Nastaví barevné téma pro vodopád"
+        }
+    }
+}


### PR DESCRIPTION
I have not so much idea if I have to use "cz_Czech" or translate that "Czech" as I did it..

Since in GUI is visible filename and not language name in some applications in Language selector is Czech, in some "Cestina"

Maybe translated names is better for non-english speaking peoples ? Japanese would be then like `jp_日本語.json` instead of `jp_Japanese.json`