### PR TITLE
fix send_arq_raw: busy check always fired, and the command class didn't exist

### DIFF
--- a/freedata_server/api/modem.py
+++ b/freedata_server/api/modem.py
@@ -464,7 +464,7 @@ async def post_arq_raw(
         api_abort("Invalid 'type' parameter.", 400)
     if not raw_data:
         api_abort("Missing 'data' parameter.", 400)
-    await enqueue_tx_command(ctx, command_arq_raw.SendARQRawCommand, payload)
+    await enqueue_tx_command(ctx, command_arq_raw.ARQRawCommand, payload)
     return api_response({"data": raw_data, "dxcall": dxcall, "type": data_type})
 
 

--- a/freedata_server/api/modem.py
+++ b/freedata_server/api/modem.py
@@ -453,7 +453,7 @@ async def post_arq_raw(
     """
     if not ctx.state_manager.is_modem_running:
         api_abort("Modem not running.", 503)
-    if ctx.state_manager.is_modem_busy:
+    if ctx.state_manager.getARQ():
         api_abort("Modem Busy.", 503)
     dxcall = payload.get("dxcall")
     data_type = payload.get("type")


### PR DESCRIPTION
Two one-line fixes that make `POST /modem/send_arq_raw` usable. Found
while pointing an automated interop rig at the raw ARQ API. The full
story is in #1108.

* `is_modem_busy` is a `threading.Event`, so
  `if ctx.state_manager.is_modem_busy:` is always true and every
  request got 503 Modem Busy. Switched to `getARQ()` to match the
  beacon, message-send and CQ-handler call sites. Deliberately not
  `.is_set()`: `setARQ(True)` clears the event, so `is_set()` would
  invert the check.
* The endpoint then referenced `command_arq_raw.SendARQRawCommand`,
  which doesn't exist; the class is `ARQRawCommand`. The 503 bug had
  been masking the AttributeError, so I'm fairly confident this
  endpoint has never run end to end before.

Tested with two instances over a simulated audio channel: raw session
completes, 512/512 bytes, checksum verified on both sides.
