### PR TITLE
restore the IRS success event that was lost in an April 2024 merge

### DIFF
--- a/freedata_server/arq_session_irs.py
+++ b/freedata_server/arq_session_irs.py
@@ -373,6 +373,17 @@ class ARQSessionIRS(arq_session.ARQSession):
             self.session_ended = time.time()
             self.set_state(IRS_State.ENDED)
 
+            session_stats = self.calculate_session_statistics(self.received_bytes, self.total_length)
+            self.ctx.event_manager.send_arq_session_finished(
+                False,
+                self.id,
+                self.dxcall,
+                True,
+                self.state.name,
+                data=self.received_data,
+                statistics=session_stats,
+            )
+
             return self.received_data, self.type_byte
         else:
             ack = self.frame_factory.build_arq_burst_ack(

--- a/tests/test_arq_session.py
+++ b/tests/test_arq_session.py
@@ -154,6 +154,47 @@ class TestARQSession(unittest.TestCase):
         # self.ctx_IRS.shutdown()
         # self.ctx_ISS.shutdown()
 
+    def testARQSessionIRSSuccessEmitsFinishedEvent(self):
+        # Gap 3 regression test: a completed IRS session must emit exactly
+        # one "arq-transfer-inbound" event with success=True, and the
+        # payload must round-trip through the event's base64 data field
+        # (previously the success branch in arq_session_irs.py never called
+        # send_arq_session_finished at all, so no such event was ever
+        # emitted -- only the abort/failure paths did).
+        self.loss_probability = 0
+        payload = np.random.bytes(200)
+
+        self.establishChannels()
+        params = {
+            "dxcall": "AA1AAA-1",
+            "data": base64.b64encode(payload),
+            # "raw" (not "raw_lzma"): the event's data field carries the
+            # bytes as received over the air, before ARQDataTypeHandler's
+            # separate decompression step -- "raw" keeps this an honest
+            # exact-match round-trip check instead of asserting equality
+            # against still-compressed bytes.
+            "type": "raw",
+        }
+        cmd = ARQRawCommand(self.ctx_ISS, params)
+        cmd.run()
+        self.waitForSession(self.ctx_ISS.TESTMODE_EVENTS, True)
+        self.channels_running = False
+
+        finished_events = []
+        while not self.ctx_IRS.TESTMODE_EVENTS.empty():
+            ev = self.ctx_IRS.TESTMODE_EVENTS.get()
+            if "arq-transfer-inbound" in ev:
+                finished_events.append(ev["arq-transfer-inbound"])
+
+        successes = [e for e in finished_events if e.get("success") is True]
+        self.assertEqual(
+            len(successes),
+            1,
+            f"expected exactly one successful arq-transfer-inbound event, got {finished_events}",
+        )
+        received = base64.b64decode(successes[0]["data"])
+        self.assertEqual(received, payload)
+
     def DisabledtestARQSessionAbortTransmissionISS(self):
         # set Packet Error Rate (PER) / frame loss probability
         self.loss_probability = 0


### PR DESCRIPTION
With #1109, a raw ARQ transfer completes over the air, but the
receiving station never announces it. The success branch in
`arq_session_irs.py` sets ENDED and returns without
`send_arq_session_finished`, while the abort path, the failure path,
and the sender's success path all emit one. There's no way for a
websocket or REST consumer to detect a successful inbound raw
transfer, and the received payload is dropped with it (`handle_raw`
returns the data into a call chain that ignores the return value).
Full story in #1108.

This used to work. c2388a65 ("bringing back statistics", 2024-04-02)
emitted exactly this event, `data=` included, and it disappeared by
ef18f4cc (2024-04-07) even though that commit's IRS diff doesn't touch
those lines. It looks like a merge casualty rather than a decision, so
this PR puts the event call back:

```python
session_stats = self.calculate_session_statistics(self.received_bytes, self.total_length)
self.ctx.event_manager.send_arq_session_finished(
    False,
    self.id,
    self.dxcall,
    True,
    self.state.name,
    data=self.received_data,
    statistics=session_stats,
)
```

One deliberate difference from c2388a65: the original also pushed the
session statistics to the stats server, gated on
`config["STATION"]["enable_stats"]`. That key is still in
config.ini.example but no longer in config.py's STATION schema, so the
strict lookup raises KeyError today, and the two existing stats pushes
in the IRS failure and abort paths have the same latent problem. So
this PR restores just the event and leaves the stats question alone;
I flagged it separately in #1108.

A few notes:

* `outbound=False` matches the IRS abort path. The IRS failure path
  passes `True` there, which looks like its own small inconsistency;
  I left it alone here and can send a follow-up if you'd like it
  aligned.
* No `setARQ(False)` added: `dispatch()` already clears busy on this
  path.
* Regression test included: a completed IRS session emits exactly one
  finished event with `success=True`, and the payload round-trips
  through the event's base64 `data` field.
* p2p messages were never affected (they notify via
  `message_received`), which is presumably why this went unnoticed
  for two years.
* The GUI is already expecting this event: `eventHandler.js` has an
  explicit `case "ENDED"` handler for `arq-transfer-inbound` that has
  been dead code since the event stopped arriving. This PR brings the
  receive-side completion UI back to life along with the API.

This branch is independent of #1109 (both sit directly on develop);
they can land in either order.
