### PR TITLE
Lower RX audio latency and make the input callback real-time safe

### DIFF
--- a/freedata_server/modem.py
+++ b/freedata_server/modem.py
@@ -6,6 +6,7 @@ Created on Wed Dec 23 07:04:24 2020
 """
 
 import queue
+import threading
 import time
 from freedata_server import codec2
 import numpy as np
@@ -75,6 +76,15 @@ class RF:
 
         self.data_queue_received = queue.Queue()
 
+        # RX audio captured by the real-time sounddevice callback is handed to
+        # rx_audio_processing_worker through this queue, keeping the callback
+        # minimal (copy + enqueue). Running the DSP in the callback under the GIL
+        # is what makes it miss its deadline and overflow on slower CPUs.
+        self.rx_audio_in_queue = queue.Queue(maxsize=100)
+        self.rx_audio_worker_running = False
+        self.rx_audio_worker_thread = None
+        self.rx_audio_dropped_blocks = 0
+
         self.demodulator = demodulator.Demodulator(self.ctx)
         self.modulator = modulator.Modulator(self.ctx)
 
@@ -116,6 +126,12 @@ class RF:
             # self.stream = lambda: None
             # self.stream.active = False
             # self.stream.stop
+            # stop the RX audio processing worker before closing the streams
+            self.rx_audio_worker_running = False
+            try:
+                self.rx_audio_in_queue.put_nowait(None)
+            except queue.Full:
+                pass
             self.sd_input_stream.close()
             self.sd_output_stream.close()
         except Exception as e:
@@ -172,6 +188,15 @@ class RF:
                 blocksize=4800,
             )
             self.sd_input_stream.start()
+
+            # process RX audio off the real-time callback thread
+            self.rx_audio_worker_running = True
+            self.rx_audio_worker_thread = threading.Thread(
+                target=self.rx_audio_processing_worker,
+                name="rx_audio_processing_worker",
+                daemon=True,
+            )
+            self.rx_audio_worker_thread.start()
 
             self.sd_output_stream = sd.OutputStream(
                 channels=1,
@@ -415,34 +440,60 @@ class RF:
             # if status.input_overflow:
             #    self.self.ctx.modem_service.put("restart")
             return
+        # Keep this real-time callback minimal: copy the captured block and hand
+        # it to rx_audio_processing_worker. The DSP (resample, FFT, demod-buffer
+        # push) runs there so a long GIL hold by another thread cannot stall this
+        # callback and cause a sounddevice input overflow on slower hardware.
         try:
-            audio_48k = np.frombuffer(indata, dtype=np.int16)
-            audio_8k = self.resampler.resample48_to_8(audio_48k)
+            self.rx_audio_in_queue.put_nowait(indata.copy())
+        except queue.Full:
+            # worker is not draining fast enough; drop this block (counted)
+            self.rx_audio_dropped_blocks += 1
 
-            self.enqueue_streaming_audio_chunks(audio_8k, self.ctx.audio_rx_queue)
+    def rx_audio_processing_worker(self) -> None:
+        """Performs all RX audio DSP off the real-time input callback.
 
-            if self.ctx.config_manager.config["AUDIO"].get("rx_auto_audio_level"):
-                audio_8k = audio.normalize_audio(audio_8k)
+        Drains rx_audio_in_queue (raw 48 kHz int16 blocks copied by
+        sd_input_audio_callback) and runs the resample to 8 kHz, optional
+        level/FFT processing and the demodulator-buffer push on a normal
+        worker thread, so the audio callback is never blocked by these
+        operations (or by the GIL while another thread holds it).
+        """
+        while self.rx_audio_worker_running:
+            try:
+                indata = self.rx_audio_in_queue.get(timeout=0.5)
+            except queue.Empty:
+                continue
+            if indata is None:  # shutdown sentinel
+                break
+            try:
+                audio_48k = np.frombuffer(indata, dtype=np.int16)
+                audio_8k = self.resampler.resample48_to_8(audio_48k)
 
-            audio_8k_level_adjusted = audio.set_audio_volume(audio_8k, self.rx_audio_level)
+                self.enqueue_streaming_audio_chunks(audio_8k, self.ctx.audio_rx_queue)
 
-            if not self.ctx.state_manager.isTransmitting():
-                audio.calculate_fft(audio_8k_level_adjusted, self.ctx.modem_fft, self.ctx.state_manager)
+                if self.ctx.config_manager.config["AUDIO"].get("rx_auto_audio_level"):
+                    audio_8k = audio.normalize_audio(audio_8k)
 
-            length_audio_8k_level_adjusted = len(audio_8k_level_adjusted)
-            # Avoid buffer overflow by filling only if buffer for
-            # selected datachannel mode is not full
-            index = 0
-            for mode in self.demodulator.MODE_DICT:
-                mode_data = self.demodulator.MODE_DICT[mode]
-                audiobuffer = mode_data["audio_buffer"]
-                decode = mode_data["decode"]
-                index += 1
-                if audiobuffer:
-                    if (audiobuffer.nbuffer + length_audio_8k_level_adjusted) > audiobuffer.size:
-                        self.demodulator.buffer_overflow_counter[index] += 1
-                        self.ctx.event_manager.send_buffer_overflow(self.demodulator.buffer_overflow_counter)
-                    elif decode:
-                        audiobuffer.push(audio_8k_level_adjusted)
-        except Exception as e:
-            self.log.warning("[AUDIO EXCEPTION]", status=status, time=time, frames=frames, e=e)
+                audio_8k_level_adjusted = audio.set_audio_volume(audio_8k, self.rx_audio_level)
+
+                if not self.ctx.state_manager.isTransmitting():
+                    audio.calculate_fft(audio_8k_level_adjusted, self.ctx.modem_fft, self.ctx.state_manager)
+
+                length_audio_8k_level_adjusted = len(audio_8k_level_adjusted)
+                # Avoid buffer overflow by filling only if buffer for
+                # selected datachannel mode is not full
+                index = 0
+                for mode in self.demodulator.MODE_DICT:
+                    mode_data = self.demodulator.MODE_DICT[mode]
+                    audiobuffer = mode_data["audio_buffer"]
+                    decode = mode_data["decode"]
+                    index += 1
+                    if audiobuffer:
+                        if (audiobuffer.nbuffer + length_audio_8k_level_adjusted) > audiobuffer.size:
+                            self.demodulator.buffer_overflow_counter[index] += 1
+                            self.ctx.event_manager.send_buffer_overflow(self.demodulator.buffer_overflow_counter)
+                        elif decode:
+                            audiobuffer.push(audio_8k_level_adjusted)
+            except Exception as e:
+                self.log.warning("[AUDIO EXCEPTION]", e=e)

--- a/freedata_server/modem.py
+++ b/freedata_server/modem.py
@@ -179,13 +179,22 @@ class RF:
             self.resampler = codec2.resampler()
 
             # SoundDevice audio input stream
+            # blocksize=0 lets PortAudio deliver small blocks, keeping RX
+            # buffering delay low. latency=0.2 sets the ring depth explicitly:
+            # the default ("high") can negotiate as little as two periods on
+            # some devices (measured on snd-aloop, where a two period ring at
+            # 100 ms periods drops audio continuously), and with blocksize=0
+            # alone the ring can come out as shallow as 40 ms. An explicit
+            # 200 ms request gives a deep ring of small periods on every
+            # device we measured (CM108 hardware and snd-aloop alike).
             self.sd_input_stream = sd.InputStream(
                 channels=1,
                 dtype="int16",
                 callback=self.sd_input_audio_callback,
                 device=in_dev_index,
                 samplerate=self.AUDIO_SAMPLE_RATE,
-                blocksize=4800,
+                blocksize=0,
+                latency=0.2,
             )
             self.sd_input_stream.start()
 

--- a/tests/test_rx_audio_callback.py
+++ b/tests/test_rx_audio_callback.py
@@ -1,0 +1,91 @@
+"""Tests for the real-time-safe RX audio callback / worker split.
+
+modem.RF.sd_input_audio_callback no longer runs the RX DSP inline; it copies the
+captured block onto rx_audio_in_queue and returns, and rx_audio_processing_worker
+drains that queue and runs the DSP (resample 48->8 kHz, FFT, demod-buffer push).
+
+These tests exercise that split directly with synthetic blocks, so they need no
+audio hardware (CI has none). They cover:
+  - the worker actually performs the relocated DSP on an enqueued block, and
+  - the callback drops (and counts) instead of blocking when the queue is full,
+    which is the real-time-safety property the change exists to provide.
+"""
+
+import threading
+import time
+import unittest
+
+import numpy as np
+
+from freedata_server.context import AppContext
+from freedata_server import modem, codec2
+
+CONFIG = "freedata_server/config.ini.example"
+BLOCK_FRAMES = 4800  # one 48 kHz input block, matching sd.InputStream(blocksize=4800)
+
+
+def _rf():
+    """A real RF wired to a real AppContext, without opening audio devices.
+
+    start_modem() would normally create the resampler (and, in TESTMODE, start
+    the demodulator decode threads); we only need the resampler here, so we set
+    it directly and leave the demod buffers as None -- the worker's buffer-push
+    is guarded by `if audiobuffer` and is intentionally not under test.
+    """
+    ctx = AppContext(CONFIG)
+    ctx.TESTMODE = True
+    rf = modem.RF(ctx)
+    rf.resampler = codec2.resampler()
+    return rf
+
+
+def _block():
+    # sounddevice delivers indata as shape (frames, channels); int16 mono here.
+    return (np.random.randn(BLOCK_FRAMES, 1) * 3000).astype(np.int16)
+
+
+class TestRxAudioCallbackWorkerSplit(unittest.TestCase):
+    def test_worker_processes_enqueued_block(self):
+        """A block handed to the callback is drained and DSP'd by the worker."""
+        rf = _rf()
+        rf.rx_audio_worker_running = True
+        worker = threading.Thread(target=rf.rx_audio_processing_worker, daemon=True)
+        worker.start()
+        try:
+            # status=None -> the block is enqueued (a truthy status is an
+            # over/underflow and is dropped by the callback, unchanged by this PR).
+            rf.sd_input_audio_callback(_block(), BLOCK_FRAMES, None, None)
+
+            # The worker resamples to 8 kHz and feeds enqueue_streaming_audio_chunks,
+            # which lands on ctx.audio_rx_queue -- our deterministic "DSP ran" signal.
+            deadline = time.time() + 5
+            while rf.ctx.audio_rx_queue.qsize() == 0 and time.time() < deadline:
+                time.sleep(0.02)
+
+            self.assertGreater(rf.ctx.audio_rx_queue.qsize(), 0, "worker did not process the enqueued RX audio block")
+            self.assertTrue(rf.rx_audio_in_queue.empty(), "worker should have drained the input queue")
+            self.assertEqual(rf.rx_audio_dropped_blocks, 0, "no block should be dropped under normal operation")
+        finally:
+            rf.rx_audio_worker_running = False
+            rf.rx_audio_in_queue.put_nowait(None)  # release the worker's get()
+            worker.join(timeout=2)
+
+    def test_callback_drops_and_does_not_block_when_queue_full(self):
+        """With the worker stalled and the queue full, the callback drops the
+        block (counted) and returns immediately -- it must never block the
+        real-time audio thread."""
+        rf = _rf()  # worker intentionally NOT started -> queue never drains
+        for _ in range(rf.rx_audio_in_queue.maxsize):
+            rf.rx_audio_in_queue.put_nowait(object())
+        self.assertTrue(rf.rx_audio_in_queue.full())
+
+        t0 = time.perf_counter()
+        rf.sd_input_audio_callback(_block(), BLOCK_FRAMES, None, None)
+        elapsed = time.perf_counter() - t0
+
+        self.assertEqual(rf.rx_audio_dropped_blocks, 1, "a full queue must drop the block and count it")
+        self.assertLess(elapsed, 0.05, "callback must not block on a full queue (real-time safety)")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This grew out of the same test rig as #1108: two FreeDATA instances
talking over a simulated audio channel (ALSA snd-aloop). On that rig
FreeDATA was completely deaf: `[AUDIO STATUS] input overflow` every
~408 ms from the moment the input stream opened, before any traffic,
and not one frame ever decoded. Digging into how the RX stream
negotiates its buffers turned into this PR. Three commits, RX side
only.

**What's in it**

1. **Run the RX DSP off the real-time input callback.** The input
   callback used to do the 48→8 kHz resample, the spectrum FFT, and the
   demod buffer pushes inline. It now copies the block onto a queue and
   returns; a worker thread does the DSP. If the queue is ever full the
   callback drops the block and counts it instead of blocking, so
   Python-side work can never stall the audio thread. The threading
   model is otherwise unchanged (RX DSP already ran off the TX thread).

2. **A unit test for that split**: the worker really performs the
   relocated DSP, and a full queue means a counted drop with the
   callback returning immediately. Needs no audio hardware.

3. **`blocksize=0` plus an explicit `latency=0.2` on the input
   stream.** This is the interesting one; numbers below.

**Why blocksize=0 + latency=0.2**

With `blocksize=4800`, PortAudio hands the demodulator fixed 100 ms
blocks, so received audio waits up to 100 ms in the input buffer before
decode can start, and that price is paid again at every turnaround of a
stop-and-wait ARQ session. `blocksize=0` lets PortAudio deliver small
blocks and cuts that to the 10–50 ms range.

But reading back the actually-negotiated ALSA parameters (from
`/proc/asound/.../hw_params` while the stream is open) showed the
defaults land badly in two different ways, depending on device:

| stream config | negotiated ring on snd-aloop | behavior |
|---|---|---|
| `blocksize=4800`, default latency | 9600 frames = 2 × 100 ms periods | overflow every 408 ms from stream open; modem deaf |
| `blocksize=0`, default latency | 1920 frames = 5 × 8 ms | clean, but only 40 ms deep |
| `blocksize=0`, `latency=0.2` | 12000 frames = 5 × 50 ms | clean, 250 ms deep |

(Identical numbers on two different machines.)

The stock configuration's failure on the loopback is structural, not
load: sounddevice's default "high" latency maps to 0.1 s there, which
at 100 ms periods is a plain double buffer, and a timer-driven virtual
device misses that service deadline on a fixed beat. It overflows with
the DSP inline or on the worker, idle or busy, and the capture side
ends up delivering only about half of real time; the modem never
decodes anything. Anyone running FreeDATA against a virtual audio cable
(automated testing, channel simulators) hits this as "RX never works".

Real hardware is a different story, which is why this isn't just
`blocksize=0`: on a Digirig CM108B, `blocksize=4800` negotiated a
200 ms ring and never overflowed, while `blocksize=0` alone shrank the
ring to ~40 ms, less margin against a short processing stall than
stock had. The explicit `latency=0.2` keeps the depth (250 ms measured
on the loopback; the CM108's own limit is 2 s so the request has room)
while keeping the small blocks. Both axes improve; nothing is traded
away.

**Validation**

- ruff check and `ruff format --check --preview` clean; the new test
  passes.
- End to end over the loopback rig: stock develop transfers 0 bytes
  (deaf, as above); this branch completes 4 KB raw-ARQ transfers intact
  at ~100 B/s on a clean simulated channel.
- The callback split alone was A/B'd against develop earlier with no
  behavior difference on either machine class; it's the enabler for
  small blocks more than a standalone fix.

If you'd rather have the latency exposed in config.ini instead of a
constant, or prefer a different depth, happy to rework. 0.2 s is the
smallest round value that keeps the measured ring at or above what
`blocksize=4800` negotiated on real hardware.
